### PR TITLE
Add Markdown and YAML parser support

### DIFF
--- a/codemap/core/indexer.py
+++ b/codemap/core/indexer.py
@@ -66,6 +66,13 @@ class Indexer:
         except ImportError:
             logger.debug("JavaScript parser not available (tree-sitter not installed)")
 
+        # Markdown and YAML parsers (always available)
+        from ..parsers.markdown_parser import MarkdownParser
+        from ..parsers.yaml_parser import YamlParser
+
+        self._parsers["markdown"] = MarkdownParser()
+        self._parsers["yaml"] = YamlParser()
+
     @classmethod
     def load_existing(cls, root: Path | None = None) -> "Indexer":
         """Load an existing codemap and create an indexer.

--- a/codemap/parsers/markdown_parser.py
+++ b/codemap/parsers/markdown_parser.py
@@ -1,0 +1,140 @@
+"""Markdown parser for indexing headers and sections."""
+
+import re
+from typing import Optional
+
+from .base import Parser, Symbol
+
+
+class MarkdownParser(Parser):
+    """Parser for Markdown files - indexes H2, H3, and H4 headers."""
+
+    # Match ##, ###, and #### headers
+    HEADER_PATTERN = re.compile(r'^(#{2,4})\s+(.+?)\s*$', re.MULTILINE)
+
+    def parse(self, source: str, filepath: Optional[str] = None) -> list[Symbol]:
+        """Parse markdown source and extract header symbols.
+
+        Args:
+            source: The markdown source code
+            filepath: Optional path to the file being parsed
+
+        Returns:
+            List of Symbol objects representing headers
+        """
+        lines = source.split('\n')
+        total_lines = len(lines)
+
+        # Find all headers with their positions
+        headers: list[tuple[int, int, str, int]] = []  # (level, line_num, title, char_pos)
+
+        for match in self.HEADER_PATTERN.finditer(source):
+            hashes = match.group(1)
+            title = match.group(2).strip()
+            level = len(hashes)  # 2 for ##, 3 for ###
+
+            # Calculate line number from character position
+            line_num = source[:match.start()].count('\n') + 1
+
+            headers.append((level, line_num, title, match.start()))
+
+        # Build symbol tree
+        symbols: list[Symbol] = []
+        h2_stack: list[Symbol] = []  # Track current H2 for nesting H3s
+        h3_stack: list[Symbol] = []  # Track current H3 for nesting H4s
+
+        for i, (level, start_line, title, _) in enumerate(headers):
+            # Find end line (start of next header at same or higher level, or EOF)
+            end_line = total_lines
+            for j in range(i + 1, len(headers)):
+                next_level, next_line, _, _ = headers[j]
+                if next_level <= level:
+                    end_line = next_line - 1
+                    break
+
+            # Determine symbol type based on header level
+            symbol_type = {2: "section", 3: "subsection", 4: "subsubsection"}.get(
+                level, "section"
+            )
+
+            symbol = Symbol(
+                name=title,
+                type=symbol_type,
+                lines=(start_line, end_line),
+                signature=None,
+                docstring=self._extract_first_paragraph(lines, start_line, end_line),
+                children=[],
+            )
+
+            if level == 2:
+                # H2: Add to root symbols and track for children
+                symbols.append(symbol)
+                h2_stack = [symbol]
+                h3_stack = []
+            elif level == 3:
+                if h2_stack:
+                    # H3: Add as child of most recent H2
+                    h2_stack[-1].children.append(symbol)
+                    h3_stack = [symbol]
+                else:
+                    # Orphan H3 - add to root
+                    symbols.append(symbol)
+                    h3_stack = [symbol]
+            elif level == 4:
+                if h3_stack:
+                    # H4: Add as child of most recent H3
+                    h3_stack[-1].children.append(symbol)
+                elif h2_stack:
+                    # No H3 parent, add to H2
+                    h2_stack[-1].children.append(symbol)
+                else:
+                    # Orphan H4 - add to root
+                    symbols.append(symbol)
+
+        return symbols
+
+    def _extract_first_paragraph(
+        self, lines: list[str], start_line: int, end_line: int
+    ) -> Optional[str]:
+        """Extract first non-empty paragraph after the header."""
+        # Start from line after header
+        content_lines = []
+        in_paragraph = False
+
+        for i in range(start_line, min(end_line, start_line + 10)):
+            if i >= len(lines):
+                break
+            line = lines[i].strip()
+
+            # Skip the header line itself
+            if i == start_line - 1:
+                continue
+
+            # Skip empty lines before content
+            if not line and not in_paragraph:
+                continue
+
+            # Stop at empty line after starting paragraph
+            if not line and in_paragraph:
+                break
+
+            # Skip code blocks, lists, etc.
+            if line.startswith('```') or line.startswith('#'):
+                break
+
+            in_paragraph = True
+            content_lines.append(line)
+
+            # Limit to ~150 chars
+            if sum(len(l) for l in content_lines) > 150:
+                break
+
+        if content_lines:
+            text = ' '.join(content_lines)
+            return text[:150] if len(text) > 150 else text
+        return None
+
+    @staticmethod
+    def supported_extensions() -> list[str]:
+        """Return list of supported file extensions."""
+        return ['.md', '.markdown']

--- a/codemap/parsers/yaml_parser.py
+++ b/codemap/parsers/yaml_parser.py
@@ -1,0 +1,172 @@
+"""YAML parser for indexing keys and sections with full hierarchy."""
+
+import re
+from typing import Optional
+
+from .base import Parser, Symbol
+
+
+class YamlParser(Parser):
+    """Parser for YAML files - indexes keys recursively with full hierarchy."""
+
+    # Match YAML keys (handles quoted and unquoted keys)
+    KEY_PATTERN = re.compile(r'^(\s*)([\w\-_]+|"[^"]+"|\'[^\']+\')\s*:')
+    # Match list items that might have nested content
+    LIST_ITEM_PATTERN = re.compile(r'^(\s*)-\s+(\w[\w\-_]*)\s*:')
+
+    def parse(self, source: str, filepath: Optional[str] = None) -> list[Symbol]:
+        """Parse YAML source and extract key symbols recursively.
+
+        Args:
+            source: The YAML source code
+            filepath: Optional path to the file being parsed
+
+        Returns:
+            List of Symbol objects representing YAML keys/sections
+        """
+        lines = source.split('\n')
+        total_lines = len(lines)
+
+        # Parse all keys with their indentation and line numbers
+        keys: list[tuple[int, str, int, bool]] = []  # (indent, name, line_num, is_list_item)
+
+        for line_num, line in enumerate(lines, 1):
+            # Skip comments and empty lines
+            stripped = line.lstrip()
+            if not stripped or stripped.startswith('#'):
+                continue
+
+            # Check for list item with key
+            list_match = self.LIST_ITEM_PATTERN.match(line)
+            if list_match:
+                indent = len(list_match.group(1)) + 2  # Account for "- "
+                key_name = list_match.group(2)
+                keys.append((indent, key_name, line_num, True))
+                continue
+
+            # Check for regular key
+            key_match = self.KEY_PATTERN.match(line)
+            if key_match:
+                indent = len(key_match.group(1))
+                key_name = key_match.group(2).strip('"\'')
+                keys.append((indent, key_name, line_num, False))
+
+        # Build hierarchical symbol tree
+        return self._build_hierarchy(keys, lines, total_lines)
+
+    def _build_hierarchy(
+        self,
+        keys: list[tuple[int, str, int, bool]],
+        lines: list[str],
+        total_lines: int,
+    ) -> list[Symbol]:
+        """Build a hierarchical symbol tree from flat key list."""
+        if not keys:
+            return []
+
+        symbols: list[Symbol] = []
+        # Stack of (indent, symbol) for tracking hierarchy
+        stack: list[tuple[int, Symbol]] = []
+
+        for i, (indent, name, start_line, is_list_item) in enumerate(keys):
+            # Find end line (next key at same or lower indent, or EOF)
+            end_line = total_lines
+            for j in range(i + 1, len(keys)):
+                next_indent, _, next_line, _ = keys[j]
+                if next_indent <= indent:
+                    end_line = next_line - 1
+                    break
+
+            # Determine symbol type
+            symbol_type = self._determine_type(lines, start_line, end_line, is_list_item)
+
+            # Extract value preview as docstring
+            docstring = self._extract_value_preview(lines, start_line)
+
+            symbol = Symbol(
+                name=name,
+                type=symbol_type,
+                lines=(start_line, end_line),
+                signature=None,
+                docstring=docstring,
+                children=[],
+            )
+
+            # Pop stack until we find parent (lower indent)
+            while stack and stack[-1][0] >= indent:
+                stack.pop()
+
+            if stack:
+                # Add as child of parent
+                stack[-1][1].children.append(symbol)
+            else:
+                # Root level symbol
+                symbols.append(symbol)
+
+            # Push current symbol to stack
+            stack.append((indent, symbol))
+
+        return symbols
+
+    def _determine_type(
+        self, lines: list[str], start_line: int, end_line: int, is_list_item: bool
+    ) -> str:
+        """Determine the type of YAML symbol based on content."""
+        if start_line > len(lines):
+            return "key"
+
+        line = lines[start_line - 1]
+
+        # Check if it's a list
+        if is_list_item:
+            return "item"
+
+        # Check what follows the colon
+        colon_idx = line.find(':')
+        if colon_idx == -1:
+            return "key"
+
+        after_colon = line[colon_idx + 1:].strip()
+
+        # Empty after colon = section/mapping
+        if not after_colon:
+            # Check if children are list items
+            if start_line < len(lines):
+                next_line = lines[start_line].lstrip()
+                if next_line.startswith('-'):
+                    return "list"
+            return "section"
+
+        # Has inline value
+        if after_colon.startswith('[') or after_colon.startswith('{'):
+            return "collection"
+        if after_colon.startswith('|') or after_colon.startswith('>'):
+            return "multiline"
+
+        return "key"
+
+    def _extract_value_preview(self, lines: list[str], line_num: int) -> Optional[str]:
+        """Extract a preview of the value for simple key-value pairs."""
+        if line_num > len(lines):
+            return None
+
+        line = lines[line_num - 1]
+        colon_idx = line.find(':')
+        if colon_idx == -1:
+            return None
+
+        value = line[colon_idx + 1:].strip()
+
+        # Skip if it's a section marker or empty
+        if not value or value in ('|', '>', '|-', '>-'):
+            return None
+
+        # Return truncated value
+        if len(value) > 100:
+            return value[:100] + "..."
+        return value if value else None
+
+    @staticmethod
+    def supported_extensions() -> list[str]:
+        """Return list of supported file extensions."""
+        return ['.yaml', '.yml']

--- a/codemap/tests/fixtures/sample_config.yaml
+++ b/codemap/tests/fixtures/sample_config.yaml
@@ -1,0 +1,105 @@
+# Sample YAML configuration for testing
+
+version: "1.0"
+name: "Sample Project"
+
+# Product metadata
+product:
+  title: "My Application"
+  description: "A sample application for testing"
+  version: 2.0
+
+# Feature definitions
+features:
+  authentication:
+    enabled: true
+    providers:
+      - oauth
+      - api_key
+    settings:
+      session_timeout: 3600
+      refresh_enabled: true
+
+  notifications:
+    email:
+      enabled: true
+      smtp_host: "smtp.example.com"
+    push:
+      enabled: false
+
+# API endpoints
+endpoints:
+  users:
+    path: "/api/users"
+    methods:
+      - GET
+      - POST
+    auth_required: true
+
+  tasks:
+    path: "/api/tasks"
+    methods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+    auth_required: true
+
+# Design system tokens
+design_system:
+  colors:
+    primary:
+      light: "#E3F2FD"
+      main: "#2196F3"
+      dark: "#1976D2"
+    secondary:
+      light: "#F3E5F5"
+      main: "#9C27B0"
+      dark: "#7B1FA2"
+
+  typography:
+    font_family: "Inter, sans-serif"
+    sizes:
+      xs: 12
+      sm: 14
+      md: 16
+      lg: 18
+      xl: 24
+
+  spacing:
+    unit: 8
+    scale:
+      - 0
+      - 4
+      - 8
+      - 16
+      - 24
+      - 32
+
+# Screen definitions
+screens:
+  - id: splash
+    title: "Splash Screen"
+    components:
+      - logo
+      - loading_indicator
+
+  - id: login
+    title: "Login Screen"
+    components:
+      - email_input
+      - password_input
+      - submit_button
+
+  - id: dashboard
+    title: "Dashboard"
+    components:
+      - header
+      - stats_cards
+      - task_list
+
+# Database configuration
+database:
+  host: "localhost"
+  port: 5432
+  name: "myapp_db"

--- a/codemap/tests/fixtures/sample_doc.md
+++ b/codemap/tests/fixtures/sample_doc.md
@@ -1,0 +1,64 @@
+# Sample Documentation
+
+This is a sample markdown file for testing the parser.
+
+## Overview
+
+This section provides an overview of the project.
+It contains multiple paragraphs of content.
+
+### Features
+
+The project has the following features:
+
+- Feature one
+- Feature two
+- Feature three
+
+#### Advanced Features
+
+These are more advanced features.
+
+### Requirements
+
+System requirements for the project.
+
+## API Reference
+
+Documentation for the API endpoints.
+
+### Authentication
+
+How to authenticate with the API.
+
+#### OAuth Flow
+
+Details about OAuth authentication.
+
+#### API Keys
+
+Using API keys for authentication.
+
+### Endpoints
+
+Available API endpoints.
+
+#### GET /users
+
+Retrieve all users.
+
+#### POST /users
+
+Create a new user.
+
+## Configuration
+
+How to configure the application.
+
+### Environment Variables
+
+List of environment variables.
+
+### Config Files
+
+Configuration file formats.

--- a/codemap/tests/test_markdown_parser.py
+++ b/codemap/tests/test_markdown_parser.py
@@ -1,0 +1,150 @@
+"""Tests for the Markdown parser."""
+
+import pytest
+
+from codemap.parsers.markdown_parser import MarkdownParser
+
+
+class TestMarkdownParser:
+    """Tests for MarkdownParser class."""
+
+    @pytest.fixture
+    def parser(self):
+        return MarkdownParser()
+
+    def test_parse_h2_headers(self, parser):
+        source = '''# Title
+
+## First Section
+
+Content here.
+
+## Second Section
+
+More content.
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 2
+        assert symbols[0].name == "First Section"
+        assert symbols[0].type == "section"
+        assert symbols[1].name == "Second Section"
+        assert symbols[1].type == "section"
+
+    def test_parse_h3_as_children(self, parser):
+        source = '''## Parent Section
+
+### Child One
+
+Content.
+
+### Child Two
+
+More content.
+
+## Another Section
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 2
+        assert symbols[0].name == "Parent Section"
+        assert len(symbols[0].children) == 2
+        assert symbols[0].children[0].name == "Child One"
+        assert symbols[0].children[0].type == "subsection"
+        assert symbols[0].children[1].name == "Child Two"
+
+    def test_parse_h4_as_nested_children(self, parser):
+        source = '''## Section
+
+### Subsection
+
+#### Deep Item
+
+Content.
+
+#### Another Deep Item
+
+More.
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        section = symbols[0]
+        assert section.name == "Section"
+        assert len(section.children) == 1
+
+        subsection = section.children[0]
+        assert subsection.name == "Subsection"
+        assert len(subsection.children) == 2
+        assert subsection.children[0].name == "Deep Item"
+        assert subsection.children[0].type == "subsubsection"
+
+    def test_line_ranges(self, parser):
+        source = '''## Section One
+
+Line 3
+Line 4
+
+## Section Two
+
+Line 8
+'''
+        symbols = parser.parse(source)
+
+        assert symbols[0].lines[0] == 1  # H2 at line 1
+        assert symbols[0].lines[1] == 5  # Ends before next H2
+        assert symbols[1].lines[0] == 6  # H2 at line 6
+
+    def test_docstring_extraction(self, parser):
+        source = '''## API Reference
+
+This section documents the API endpoints.
+Use this to integrate with our system.
+
+### Endpoints
+'''
+        symbols = parser.parse(source)
+
+        assert symbols[0].docstring is not None
+        assert "API endpoints" in symbols[0].docstring
+
+    def test_orphan_h3_at_root(self, parser):
+        source = '''### Orphan Header
+
+Content without parent H2.
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        assert symbols[0].name == "Orphan Header"
+        assert symbols[0].type == "subsection"
+
+    def test_parse_fixture_file(self, parser):
+        """Test parsing the markdown fixture file."""
+        import os
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "sample_doc.md"
+        )
+        with open(fixture_path, "r") as f:
+            source = f.read()
+
+        symbols = parser.parse(source, fixture_path)
+
+        # Should find H2 sections
+        assert len(symbols) >= 3
+        names = [s.name for s in symbols]
+        assert "Overview" in names
+        assert "API Reference" in names
+        assert "Configuration" in names
+
+        # Check nested structure
+        api_section = next(s for s in symbols if s.name == "API Reference")
+        assert len(api_section.children) >= 2
+        child_names = [c.name for c in api_section.children]
+        assert "Authentication" in child_names
+        assert "Endpoints" in child_names
+
+    def test_supported_extensions(self, parser):
+        extensions = parser.supported_extensions()
+        assert ".md" in extensions
+        assert ".markdown" in extensions

--- a/codemap/tests/test_yaml_parser.py
+++ b/codemap/tests/test_yaml_parser.py
@@ -1,0 +1,169 @@
+"""Tests for the YAML parser."""
+
+import pytest
+
+from codemap.parsers.yaml_parser import YamlParser
+
+
+class TestYamlParser:
+    """Tests for YamlParser class."""
+
+    @pytest.fixture
+    def parser(self):
+        return YamlParser()
+
+    def test_parse_simple_keys(self, parser):
+        source = '''name: "Test Project"
+version: "1.0"
+author: "Test Author"
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 3
+        assert symbols[0].name == "name"
+        assert symbols[0].type == "key"
+        assert symbols[1].name == "version"
+        assert symbols[2].name == "author"
+
+    def test_parse_nested_keys(self, parser):
+        source = '''database:
+  host: localhost
+  port: 5432
+  name: mydb
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        assert symbols[0].name == "database"
+        assert symbols[0].type == "section"
+        assert len(symbols[0].children) == 3
+        assert symbols[0].children[0].name == "host"
+        assert symbols[0].children[1].name == "port"
+        assert symbols[0].children[2].name == "name"
+
+    def test_parse_deep_hierarchy(self, parser):
+        source = '''config:
+  features:
+    auth:
+      enabled: true
+      providers:
+        oauth: true
+        api_key: false
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        config = symbols[0]
+        assert config.name == "config"
+
+        features = config.children[0]
+        assert features.name == "features"
+
+        auth = features.children[0]
+        assert auth.name == "auth"
+        assert len(auth.children) >= 2
+
+    def test_parse_list_section(self, parser):
+        source = '''screens:
+  - id: splash
+    title: "Splash"
+  - id: login
+    title: "Login"
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        screens = symbols[0]
+        assert screens.name == "screens"
+        # List items with keys are captured
+        assert len(screens.children) >= 2
+
+    def test_line_ranges(self, parser):
+        source = '''first:
+  key1: value1
+  key2: value2
+second:
+  key3: value3
+'''
+        symbols = parser.parse(source)
+
+        assert symbols[0].lines[0] == 1
+        assert symbols[0].lines[1] == 3  # Ends before 'second'
+        assert symbols[1].lines[0] == 4
+
+    def test_value_preview_as_docstring(self, parser):
+        source = '''name: "My Application"
+description: "A really long description that goes on and on"
+'''
+        symbols = parser.parse(source)
+
+        assert symbols[0].docstring == '"My Application"'
+        assert symbols[1].docstring is not None
+
+    def test_section_has_no_value_docstring(self, parser):
+        source = '''config:
+  key: value
+'''
+        symbols = parser.parse(source)
+
+        # Section markers shouldn't have value previews
+        assert symbols[0].docstring is None
+
+    def test_parse_quoted_keys(self, parser):
+        source = '''"special-key": value1
+'another-key': value2
+normal_key: value3
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 3
+        assert symbols[0].name == "special-key"
+        assert symbols[1].name == "another-key"
+        assert symbols[2].name == "normal_key"
+
+    def test_skip_comments(self, parser):
+        source = '''# This is a comment
+name: value
+# Another comment
+other: value2
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 2
+        assert symbols[0].name == "name"
+        assert symbols[1].name == "other"
+
+    def test_parse_fixture_file(self, parser):
+        """Test parsing the YAML fixture file."""
+        import os
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "sample_config.yaml"
+        )
+        with open(fixture_path, "r") as f:
+            source = f.read()
+
+        symbols = parser.parse(source, fixture_path)
+
+        # Should find root level keys
+        names = [s.name for s in symbols]
+        assert "version" in names
+        assert "product" in names
+        assert "features" in names
+        assert "design_system" in names
+
+        # Check nested structure
+        features = next(s for s in symbols if s.name == "features")
+        feature_names = [c.name for c in features.children]
+        assert "authentication" in feature_names
+        assert "notifications" in feature_names
+
+        # Check deep nesting
+        design = next(s for s in symbols if s.name == "design_system")
+        design_names = [c.name for c in design.children]
+        assert "colors" in design_names
+        assert "typography" in design_names
+
+    def test_supported_extensions(self, parser):
+        extensions = parser.supported_extensions()
+        assert ".yaml" in extensions
+        assert ".yml" in extensions

--- a/codemap/utils/config.py
+++ b/codemap/utils/config.py
@@ -16,6 +16,9 @@ DEFAULT_INCLUDE_PATTERNS = [
     "**/*.tsx",
     "**/*.js",
     "**/*.jsx",
+    "**/*.md",
+    "**/*.yaml",
+    "**/*.yml",
 ]
 
 DEFAULT_EXCLUDE_PATTERNS = [
@@ -38,7 +41,7 @@ DEFAULT_EXCLUDE_PATTERNS = [
 class Config:
     """CodeMap configuration."""
 
-    languages: list[str] = field(default_factory=lambda: ["python", "typescript", "javascript"])
+    languages: list[str] = field(default_factory=lambda: ["python", "typescript", "javascript", "markdown", "yaml"])
     exclude_patterns: list[str] = field(default_factory=lambda: DEFAULT_EXCLUDE_PATTERNS.copy())
     include_patterns: list[str] = field(default_factory=lambda: DEFAULT_INCLUDE_PATTERNS.copy())
     max_docstring_length: int = 150

--- a/codemap/utils/file_utils.py
+++ b/codemap/utils/file_utils.py
@@ -97,6 +97,8 @@ def _get_extensions_for_languages(languages: list[str]) -> list[str]:
         "python": [".py", ".pyi"],
         "typescript": [".ts", ".tsx"],
         "javascript": [".js", ".jsx"],
+        "markdown": [".md", ".markdown"],
+        "yaml": [".yaml", ".yml"],
     }
 
     extensions = []
@@ -140,5 +142,9 @@ def get_language(filepath: Path) -> str | None:
         ".tsx": "typescript",
         ".js": "javascript",
         ".jsx": "javascript",
+        ".md": "markdown",
+        ".markdown": "markdown",
+        ".yaml": "yaml",
+        ".yml": "yaml",
     }
     return extension_to_lang.get(suffix)


### PR DESCRIPTION
## Summary

Adds support for indexing Markdown and YAML files, enabling efficient navigation of documentation and configuration files.

### New Parsers

- **Markdown Parser** - Indexes H2, H3, and H4 headers with hierarchical nesting
- **YAML Parser** - Full recursive key hierarchy indexing

### Symbol Types Added

| Parser | Symbol Types |
|--------|--------------|
| Markdown | `section`, `subsection`, `subsubsection` |
| YAML | `key`, `section`, `list`, `item`, `collection`, `multiline` |

### Files Changed

- `codemap/parsers/markdown_parser.py` (new)
- `codemap/parsers/yaml_parser.py` (new)
- `codemap/core/indexer.py` - Register new parsers
- `codemap/utils/file_utils.py` - Add extension mappings
- `codemap/utils/config.py` - Add to default languages

### Test Results

- 19 new tests added (8 markdown, 11 yaml)
- All 194 tests passing

### Real-World Testing (HouseKeeping Project)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Files indexed | 261 | 322 | +61 |
| Symbols indexed | 678 | 7,159 | +6,481 |
| Markdown files | 0 | 49 | +49 |
| YAML files | 0 | 12 | +12 |

### Example Usage

```bash
# Find sections in markdown docs
codemap find "Authentication"
# → docs/api-contract.md:65-308 [section] Authentication

# Find keys in YAML config
codemap find "colors"
# → design-artifacts/design-system.yaml:36-182 [section] colors

# Show structure of a YAML file
codemap show design-artifacts/styled-dsl.yaml
```

## Test Plan

- [x] Run `pytest tests/test_markdown_parser.py` - 8 tests pass
- [x] Run `pytest tests/test_yaml_parser.py` - 11 tests pass
- [x] Run full test suite - 194 tests pass
- [x] Test on real project (HouseKeeping) - indexes 61 new files

🤖 Generated with [Claude Code](https://claude.ai/code)