### PR TITLE
feat: Add Dart parser support for Flutter/Dart projects

### DIFF
--- a/codemap/parsers/__init__.py
+++ b/codemap/parsers/__init__.py
@@ -85,6 +85,12 @@ try:
 except ImportError:
     PHPParser = None
 
+try:
+    from .dart_parser import DartParser
+    __all__.append("DartParser")
+except ImportError:
+    DartParser = None
+
 
 def get_available_parsers() -> list[type[Parser]]:
     """Return list of all available parser classes."""
@@ -116,6 +122,8 @@ def get_available_parsers() -> list[type[Parser]]:
         parsers.append(CssParser)
     if PHPParser:
         parsers.append(PHPParser)
+    if DartParser:
+        parsers.append(DartParser)
 
     return parsers
 

--- a/codemap/parsers/dart_parser.py
+++ b/codemap/parsers/dart_parser.py
@@ -1,0 +1,399 @@
+"""Dart parser using tree-sitter-language-pack for Flutter/Dart projects."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .treesitter_base import TreeSitterParser, LanguageConfig, NodeMapping
+from .base import Symbol
+
+# Tree-sitter imports - uses language-pack since standalone dart package unavailable
+try:
+    from tree_sitter import Parser as TSParser
+    from tree_sitter_language_pack import get_language
+    TREE_SITTER_AVAILABLE = True
+except ImportError:
+    TREE_SITTER_AVAILABLE = False
+
+
+DART_CONFIG = LanguageConfig(
+    name="dart",
+    extensions=[".dart"],
+    grammar_module="dart",  # Not used directly - we use language-pack
+    node_mappings={
+        # Classes
+        "class_definition": NodeMapping(
+            symbol_type="class",
+            name_child="identifier",
+            body_child="class_body",
+        ),
+        # Enums
+        "enum_declaration": NodeMapping(
+            symbol_type="enum",
+            name_child="identifier",
+            body_child="enum_body",
+        ),
+        # Mixins
+        "mixin_declaration": NodeMapping(
+            symbol_type="mixin",
+            name_child="identifier",
+            body_child="class_body",
+        ),
+        # Extensions
+        "extension_declaration": NodeMapping(
+            symbol_type="extension",
+            name_child="identifier",
+            body_child="extension_body",
+        ),
+        # Top-level functions (function_signature node)
+        "function_signature": NodeMapping(
+            symbol_type="function",
+            name_child="identifier",
+            signature_child="formal_parameter_list",
+        ),
+    },
+    comment_types=["documentation_comment", "comment"],
+    doc_comment_prefix="///",
+)
+
+
+class DartParser(TreeSitterParser):
+    """Parser for Dart files using tree-sitter.
+
+    Supports Dart/Flutter features including:
+    - Classes (including abstract classes)
+    - Enums
+    - Mixins
+    - Extensions
+    - Top-level functions
+    - Methods (including getters, setters, factory constructors)
+    - Named constructors
+    - Documentation comments (///)
+    """
+
+    config = DART_CONFIG
+    extensions = [".dart"]
+    language = "dart"
+
+    def __init__(self):
+        """Initialize the Dart parser using tree-sitter-language-pack."""
+        if not TREE_SITTER_AVAILABLE:
+            raise ImportError(
+                "tree-sitter and tree-sitter-language-pack are required. "
+                "Install with: pip install tree-sitter tree-sitter-language-pack"
+            )
+        self._parser = TSParser(get_language("dart"))
+
+    def _extract_symbols(self, node, source_bytes: bytes) -> list[Symbol]:
+        """Extract symbols from AST node."""
+        symbols = []
+        prev_doc = None
+
+        for child in node.children:
+            # Track documentation comments
+            if child.type == "documentation_comment":
+                prev_doc = self._extract_doc_comment(child, source_bytes)
+                continue
+
+            symbol = self._extract_symbol(child, source_bytes, prev_doc)
+            if symbol:
+                symbols.append(symbol)
+            prev_doc = None
+
+        return symbols
+
+    def _extract_symbol(
+        self, node, source_bytes: bytes, docstring: Optional[str] = None
+    ) -> Optional[Symbol]:
+        """Extract a symbol from a node with Dart-specific handling."""
+        # Handle class definition (including abstract)
+        if node.type == "class_definition":
+            return self._extract_class(node, source_bytes, docstring)
+
+        # Handle enum
+        if node.type == "enum_declaration":
+            return self._extract_enum(node, source_bytes, docstring)
+
+        # Handle mixin
+        if node.type == "mixin_declaration":
+            return self._extract_mixin(node, source_bytes, docstring)
+
+        # Handle extension
+        if node.type == "extension_declaration":
+            return self._extract_extension(node, source_bytes, docstring)
+
+        # Handle top-level function
+        if node.type == "function_signature":
+            return self._extract_top_level_function(node, source_bytes, docstring)
+
+        return None
+
+    def _extract_class(
+        self, node, source_bytes: bytes, docstring: Optional[str]
+    ) -> Symbol:
+        """Extract class definition (including abstract classes)."""
+        name = self._get_child_text(node, "identifier", source_bytes)
+        is_abstract = any(c.type == "abstract" for c in node.children)
+
+        # Extract children from class body
+        children = []
+        body_node = self._find_child(node, "class_body")
+        if body_node:
+            children = self._extract_class_members(body_node, source_bytes)
+
+        return Symbol(
+            name=name,
+            type="class",
+            lines=(node.start_point[0] + 1, node.end_point[0] + 1),
+            signature=f"{'abstract ' if is_abstract else ''}class {name}",
+            docstring=docstring,
+            children=children if children else None,
+        )
+
+    def _extract_enum(
+        self, node, source_bytes: bytes, docstring: Optional[str]
+    ) -> Symbol:
+        """Extract enum declaration."""
+        name = self._get_child_text(node, "identifier", source_bytes)
+
+        return Symbol(
+            name=name,
+            type="enum",
+            lines=(node.start_point[0] + 1, node.end_point[0] + 1),
+            signature=f"enum {name}",
+            docstring=docstring,
+            children=None,
+        )
+
+    def _extract_mixin(
+        self, node, source_bytes: bytes, docstring: Optional[str]
+    ) -> Symbol:
+        """Extract mixin declaration."""
+        name = self._get_child_text(node, "identifier", source_bytes)
+
+        # Extract children from class body
+        children = []
+        body_node = self._find_child(node, "class_body")
+        if body_node:
+            children = self._extract_class_members(body_node, source_bytes)
+
+        return Symbol(
+            name=name,
+            type="mixin",
+            lines=(node.start_point[0] + 1, node.end_point[0] + 1),
+            signature=f"mixin {name}",
+            docstring=docstring,
+            children=children if children else None,
+        )
+
+    def _extract_extension(
+        self, node, source_bytes: bytes, docstring: Optional[str]
+    ) -> Symbol:
+        """Extract extension declaration."""
+        name = self._get_child_text(node, "identifier", source_bytes) or "<anonymous>"
+
+        # Get the 'on' type
+        on_type = None
+        found_on = False
+        for child in node.children:
+            if child.type == "on":
+                found_on = True
+            elif found_on and child.type == "type_identifier":
+                on_type = self._get_node_text(child, source_bytes)
+                break
+
+        # Extract children from extension body
+        children = []
+        body_node = self._find_child(node, "extension_body")
+        if body_node:
+            children = self._extract_class_members(body_node, source_bytes)
+
+        signature = f"extension {name}"
+        if on_type:
+            signature += f" on {on_type}"
+
+        return Symbol(
+            name=name,
+            type="extension",
+            lines=(node.start_point[0] + 1, node.end_point[0] + 1),
+            signature=signature,
+            docstring=docstring,
+            children=children if children else None,
+        )
+
+    def _extract_top_level_function(
+        self, node, source_bytes: bytes, docstring: Optional[str]
+    ) -> Symbol:
+        """Extract top-level function."""
+        name = self._get_child_text(node, "identifier", source_bytes)
+        signature = self._get_node_text(node, source_bytes)
+
+        # Find the function_body sibling to get end line
+        end_line = node.end_point[0] + 1
+        parent = node.parent
+        if parent:
+            found_sig = False
+            for sibling in parent.children:
+                if sibling == node:
+                    found_sig = True
+                elif found_sig and sibling.type == "function_body":
+                    end_line = sibling.end_point[0] + 1
+                    break
+
+        return Symbol(
+            name=name,
+            type="function",
+            lines=(node.start_point[0] + 1, end_line),
+            signature=self._truncate_signature(signature),
+            docstring=docstring,
+            children=None,
+        )
+
+    def _extract_class_members(self, body_node, source_bytes: bytes) -> list[Symbol]:
+        """Extract methods and constructors from class/mixin/extension body."""
+        members = []
+        prev_doc = None
+        prev_method_sig = None
+
+        for child in body_node.children:
+            if child.type == "documentation_comment":
+                prev_doc = self._extract_doc_comment(child, source_bytes)
+
+            elif child.type == "declaration":
+                # Check for constructor
+                constructor_sig = self._find_child(child, "constructor_signature")
+                if constructor_sig:
+                    symbol = self._extract_constructor(
+                        child, constructor_sig, source_bytes, prev_doc
+                    )
+                    if symbol:
+                        members.append(symbol)
+                prev_doc = None
+
+            elif child.type == "method_signature":
+                prev_method_sig = child
+                # Don't clear prev_doc yet - will be used with function_body
+
+            elif child.type == "function_body" and prev_method_sig:
+                symbol = self._extract_method(
+                    prev_method_sig, child, source_bytes, prev_doc
+                )
+                if symbol:
+                    members.append(symbol)
+                prev_method_sig = None
+                prev_doc = None
+
+        return members
+
+    def _extract_method(
+        self,
+        sig_node,
+        body_node,
+        source_bytes: bytes,
+        docstring: Optional[str],
+    ) -> Optional[Symbol]:
+        """Extract method from method_signature + function_body."""
+        # method_signature can contain: function_signature, getter_signature,
+        # setter_signature, factory_constructor_signature
+        inner_sig = None
+        for child in sig_node.children:
+            if child.type in (
+                "function_signature",
+                "getter_signature",
+                "setter_signature",
+                "factory_constructor_signature",
+            ):
+                inner_sig = child
+                break
+
+        if not inner_sig:
+            return None
+
+        name = self._get_child_text(inner_sig, "identifier", source_bytes)
+        signature = self._get_node_text(sig_node, source_bytes)
+
+        # Determine type based on inner signature
+        if inner_sig.type == "getter_signature":
+            symbol_type = "getter"
+        elif inner_sig.type == "setter_signature":
+            symbol_type = "setter"
+        elif inner_sig.type == "factory_constructor_signature":
+            symbol_type = "constructor"
+            # For factory constructors, get the full name (ClassName.factoryName)
+            identifiers = [c for c in inner_sig.children if c.type == "identifier"]
+            if len(identifiers) >= 2:
+                class_name = self._get_node_text(identifiers[0], source_bytes)
+                factory_name = self._get_node_text(identifiers[1], source_bytes)
+                name = f"{class_name}.{factory_name}"
+        else:
+            symbol_type = "method"
+
+        return Symbol(
+            name=name,
+            type=symbol_type,
+            lines=(sig_node.start_point[0] + 1, body_node.end_point[0] + 1),
+            signature=self._truncate_signature(signature),
+            docstring=docstring,
+            children=None,
+        )
+
+    def _extract_constructor(
+        self,
+        decl_node,
+        sig_node,
+        source_bytes: bytes,
+        docstring: Optional[str],
+    ) -> Optional[Symbol]:
+        """Extract constructor from declaration with constructor_signature."""
+        identifiers = [c for c in sig_node.children if c.type == "identifier"]
+        if not identifiers:
+            return None
+
+        # Get constructor name (ClassName or ClassName.namedConstructor)
+        if len(identifiers) >= 2:
+            class_name = self._get_node_text(identifiers[0], source_bytes)
+            constructor_name = self._get_node_text(identifiers[1], source_bytes)
+            name = f"{class_name}.{constructor_name}"
+        else:
+            name = self._get_node_text(identifiers[0], source_bytes)
+
+        signature = self._get_node_text(sig_node, source_bytes)
+
+        return Symbol(
+            name=name,
+            type="constructor",
+            lines=(decl_node.start_point[0] + 1, decl_node.end_point[0] + 1),
+            signature=self._truncate_signature(signature),
+            docstring=docstring,
+            children=None,
+        )
+
+    def _extract_doc_comment(self, node, source_bytes: bytes) -> Optional[str]:
+        """Extract and clean documentation comment."""
+        text = self._get_node_text(node, source_bytes)
+        # Remove /// prefixes and clean up
+        lines = []
+        for line in text.split("\n"):
+            line = line.strip()
+            if line.startswith("///"):
+                line = line[3:].strip()
+            lines.append(line)
+
+        doc = " ".join(lines).strip()
+        if doc:
+            return doc[:150]  # Truncate to 150 chars
+        return None
+
+    def _get_child_text(self, node, child_type: str, source_bytes: bytes) -> str:
+        """Get text of first child of given type."""
+        child = self._find_child(node, child_type)
+        if child:
+            return self._get_node_text(child, source_bytes)
+        return ""
+
+    def _truncate_signature(self, sig: str, max_len: int = 100) -> str:
+        """Truncate signature to max length."""
+        sig = " ".join(sig.split())  # Normalize whitespace
+        if len(sig) <= max_len:
+            return sig
+        return sig[: max_len - 3] + "..."

--- a/codemap/tests/fixtures/sample_module.dart
+++ b/codemap/tests/fixtures/sample_module.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+
+/// Represents a user in the system.
+class User {
+  final int id;
+  final String name;
+  String? email;
+
+  /// Creates a new user with ID and name.
+  User(this.id, this.name);
+
+  /// Creates a user from JSON data.
+  User.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        name = json['name'],
+        email = json['email'];
+
+  /// Factory constructor for creating guest users.
+  factory User.guest() {
+    return User(0, 'Guest');
+  }
+
+  /// Gets the display name.
+  String getDisplayName() {
+    return '$name (#$id)';
+  }
+
+  /// Checks if user is valid.
+  bool isValid() {
+    return id > 0 && name.isNotEmpty;
+  }
+
+  /// Gets the user's initials.
+  String get initials => name.split(' ').map((n) => n[0]).join();
+
+  /// Sets the user's email with validation.
+  set userEmail(String? value) {
+    if (value == null || value.contains('@')) {
+      email = value;
+    }
+  }
+}
+
+/// Abstract service interface for user operations.
+abstract class UserService {
+  Future<User?> getUser(int id);
+  Future<User> createUser(String name);
+  Future<bool> deleteUser(int id);
+}
+
+/// Status enumeration for entities.
+enum Status { active, inactive, pending }
+
+/// Mixin for logging functionality.
+mixin Loggable {
+  /// Logs a message to console.
+  void log(String message) {
+    print('[LOG] $message');
+  }
+
+  /// Logs an error message.
+  void logError(String error) {
+    print('[ERROR] $error');
+  }
+}
+
+/// Extension methods for String utilities.
+extension StringUtils on String {
+  /// Converts string to title case.
+  String toTitleCase() {
+    return split(' ').map((word) {
+      if (word.isEmpty) return word;
+      return word[0].toUpperCase() + word.substring(1).toLowerCase();
+    }).join(' ');
+  }
+
+  /// Checks if string is a valid email.
+  bool get isValidEmail => contains('@') && contains('.');
+}
+
+/// Default implementation of UserService with logging.
+class DefaultUserService extends UserService with Loggable {
+  final Map<int, User> _users = {};
+
+  /// Retrieves a user by ID.
+  @override
+  Future<User?> getUser(int id) async {
+    log('Getting user $id');
+    return _users[id];
+  }
+
+  /// Creates a new user with the given name.
+  @override
+  Future<User> createUser(String name) async {
+    final id = _users.length + 1;
+    final user = User(id, name);
+    _users[id] = user;
+    log('Created user $name with id $id');
+    return user;
+  }
+
+  /// Deletes a user by ID.
+  @override
+  Future<bool> deleteUser(int id) async {
+    final removed = _users.remove(id) != null;
+    if (removed) {
+      log('Deleted user $id');
+    } else {
+      logError('User $id not found');
+    }
+    return removed;
+  }
+}
+
+/// Top-level function for email validation.
+bool validateEmail(String email) {
+  return email.contains('@') && email.contains('.');
+}
+
+/// Async function to fetch user data.
+Future<Map<String, dynamic>> fetchUserData(int userId) async {
+  await Future.delayed(Duration(milliseconds: 100));
+  return {'id': userId, 'name': 'User $userId'};
+}

--- a/codemap/tests/test_dart_parser.py
+++ b/codemap/tests/test_dart_parser.py
@@ -1,0 +1,315 @@
+"""Tests for the Dart parser."""
+
+import pytest
+
+# Skip all tests if tree-sitter-language-pack is not installed
+pytest.importorskip("tree_sitter_language_pack")
+
+from codemap.parsers.dart_parser import DartParser
+
+
+class TestDartParser:
+    """Tests for DartParser class."""
+
+    @pytest.fixture
+    def parser(self):
+        return DartParser()
+
+    def test_parse_simple_class(self, parser):
+        source = '''
+class User {
+  final int id;
+  final String name;
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        assert symbols[0].name == "User"
+        assert symbols[0].type == "class"
+        assert symbols[0].signature == "class User"
+
+    def test_parse_abstract_class(self, parser):
+        source = '''
+abstract class UserService {
+  Future<User> getUser(int id);
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        assert symbols[0].name == "UserService"
+        assert symbols[0].type == "class"
+        assert "abstract" in symbols[0].signature
+
+    def test_parse_class_with_methods(self, parser):
+        source = '''
+class Calculator {
+  int add(int a, int b) {
+    return a + b;
+  }
+
+  int subtract(int a, int b) {
+    return a - b;
+  }
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        calc = symbols[0]
+        assert calc.name == "Calculator"
+        assert calc.type == "class"
+        assert len(calc.children) == 2
+        assert calc.children[0].name == "add"
+        assert calc.children[0].type == "method"
+        assert calc.children[1].name == "subtract"
+        assert calc.children[1].type == "method"
+
+    def test_parse_constructor(self, parser):
+        source = '''
+class Person {
+  String name;
+
+  Person(this.name);
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        person = symbols[0]
+        assert person.name == "Person"
+        assert len(person.children) == 1
+        assert person.children[0].name == "Person"
+        assert person.children[0].type == "constructor"
+
+    def test_parse_named_constructor(self, parser):
+        source = '''
+class User {
+  int id;
+  String name;
+
+  User(this.id, this.name);
+
+  User.fromJson(Map<String, dynamic> json)
+      : id = json['id'],
+        name = json['name'];
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        user = symbols[0]
+        assert len(user.children) == 2
+
+        constructors = [c for c in user.children if c.type == "constructor"]
+        assert len(constructors) == 2
+
+        names = [c.name for c in constructors]
+        assert "User" in names
+        assert "User.fromJson" in names
+
+    def test_parse_factory_constructor(self, parser):
+        source = '''
+class Singleton {
+  static final Singleton _instance = Singleton._internal();
+
+  Singleton._internal();
+
+  factory Singleton() {
+    return _instance;
+  }
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        singleton = symbols[0]
+
+        # Should have named constructor and factory
+        constructors = [c for c in singleton.children if c.type == "constructor"]
+        assert len(constructors) >= 1
+
+    def test_parse_getter_setter(self, parser):
+        source = '''
+class Person {
+  String _name = '';
+
+  String get name => _name;
+
+  set name(String value) {
+    _name = value;
+  }
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        person = symbols[0]
+        assert len(person.children) == 2
+
+        types = {c.type for c in person.children}
+        assert "getter" in types
+        assert "setter" in types
+
+    def test_parse_enum(self, parser):
+        source = '''
+enum Status { active, inactive, pending }
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        assert symbols[0].name == "Status"
+        assert symbols[0].type == "enum"
+        assert symbols[0].signature == "enum Status"
+
+    def test_parse_mixin(self, parser):
+        source = '''
+mixin Loggable {
+  void log(String message) {
+    print(message);
+  }
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        assert symbols[0].name == "Loggable"
+        assert symbols[0].type == "mixin"
+        assert symbols[0].signature == "mixin Loggable"
+        assert len(symbols[0].children) == 1
+        assert symbols[0].children[0].name == "log"
+        assert symbols[0].children[0].type == "method"
+
+    def test_parse_extension(self, parser):
+        source = '''
+extension StringUtils on String {
+  String toTitleCase() {
+    return this[0].toUpperCase() + substring(1);
+  }
+
+  bool get isBlank => trim().isEmpty;
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        ext = symbols[0]
+        assert ext.name == "StringUtils"
+        assert ext.type == "extension"
+        assert "on String" in ext.signature
+        assert len(ext.children) == 2
+
+    def test_parse_top_level_function(self, parser):
+        source = '''
+bool validateEmail(String email) {
+  return email.contains('@');
+}
+
+int add(int a, int b) {
+  return a + b;
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 2
+        assert symbols[0].name == "validateEmail"
+        assert symbols[0].type == "function"
+        assert symbols[1].name == "add"
+        assert symbols[1].type == "function"
+
+    def test_parse_async_function(self, parser):
+        source = '''
+Future<String> fetchData() async {
+  return 'data';
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        assert symbols[0].name == "fetchData"
+        assert symbols[0].type == "function"
+
+    def test_parse_docstring(self, parser):
+        source = '''
+/// This is a documented class.
+class Documented {
+  /// This method does something.
+  void doSomething() {}
+}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        assert symbols[0].docstring == "This is a documented class."
+        assert len(symbols[0].children) == 1
+        assert symbols[0].children[0].docstring == "This method does something."
+
+    def test_parse_multiple_types(self, parser):
+        source = '''
+class First {}
+
+abstract class Second {}
+
+enum Third { a, b }
+
+mixin Fourth {}
+
+extension Fifth on String {}
+
+void sixth() {}
+'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 6
+        names = [s.name for s in symbols]
+        assert "First" in names
+        assert "Second" in names
+        assert "Third" in names
+        assert "Fourth" in names
+        assert "Fifth" in names
+        assert "sixth" in names
+
+    def test_parse_fixture_file(self, parser):
+        """Test parsing the Dart fixture file."""
+        import os
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "sample_module.dart"
+        )
+        with open(fixture_path, "r") as f:
+            source = f.read()
+
+        symbols = parser.parse(source, fixture_path)
+
+        # Should find multiple symbols
+        assert len(symbols) >= 6
+
+        names = [s.name for s in symbols]
+        assert "User" in names
+        assert "UserService" in names
+        assert "Status" in names
+        assert "Loggable" in names
+        assert "StringUtils" in names
+        assert "DefaultUserService" in names
+        assert "validateEmail" in names
+
+    def test_extensions(self, parser):
+        """Test that the parser handles the correct extensions."""
+        assert ".dart" in parser.extensions
+
+    def test_language(self, parser):
+        """Test that the parser reports the correct language."""
+        assert parser.language == "dart"
+
+    def test_line_numbers(self, parser):
+        """Test that line numbers are correctly extracted."""
+        source = '''class Test {
+  void method() {
+    print('hello');
+  }
+}'''
+        symbols = parser.parse(source)
+
+        assert len(symbols) == 1
+        assert symbols[0].lines[0] == 1  # Start at line 1
+        assert symbols[0].lines[1] == 5  # End at line 5 (closing brace)

--- a/docs/plans/language-support-roadmap.md
+++ b/docs/plans/language-support-roadmap.md
@@ -4,12 +4,14 @@
 
 ## Current Status
 
-**Supported Languages (13):**
+**Supported Languages (16):**
 - Python (stdlib ast)
 - TypeScript, JavaScript (tree-sitter)
 - Kotlin, Swift (tree-sitter)
 - Go, Java, C#, Rust (tree-sitter)
 - C, C++ (tree-sitter)
+- PHP (tree-sitter)
+- HTML, CSS (tree-sitter)
 - Markdown, YAML (custom parsers)
 
 ## Priority Tiers
@@ -29,17 +31,17 @@ Languages ranked by combined popularity from [TIOBE Index](https://www.tiobe.com
 | 7 | C | #3 | #12 (17%) | ✅ Done | tree-sitter-c |
 | 8 | Go | #8 | #13 (14%) | ✅ Done | tree-sitter-go |
 | 9 | Rust | #13 | #14 (13%) | ✅ Done | tree-sitter-rust |
-| 10 | PHP | #17 | #11 (18%) | ⏳ Planned | tree-sitter-php |
+| 10 | PHP | #17 | #11 (18%) | ✅ Done | tree-sitter-php |
 
-**Tier 1 Completion: 10/10 (100%) - Only PHP remaining!**
+**Tier 1 Completion: 10/10 (100%) ✅**
 
 ### Tier 2: High Priority (Ranks 11-25)
 
 | Rank | Language | TIOBE 2025 | Stack Overflow | Status | Package |
 |------|----------|------------|----------------|--------|---------|
 | 11 | SQL | - | #4 (52%) | ⏳ Planned | tree-sitter-sql |
-| 12 | HTML | - | #2 (54%) | ⏳ Planned | tree-sitter-html |
-| 13 | CSS/SCSS | - | #6 (42%) | ⏳ Planned | tree-sitter-css |
+| 12 | HTML | - | #2 (54%) | ✅ Done | tree-sitter-html |
+| 13 | CSS/SCSS | - | #6 (42%) | ✅ Done | tree-sitter-css |
 | 14 | Bash/Shell | - | #7 (33%) | ⏳ Planned | tree-sitter-bash |
 | 15 | Ruby | #18 | #17 (6%) | ⏳ Planned | tree-sitter-ruby |
 | 16 | Kotlin | #15 | #15 (9%) | ✅ Done | tree-sitter-kotlin |
@@ -53,7 +55,7 @@ Languages ranked by combined popularity from [TIOBE Index](https://www.tiobe.com
 | 24 | Elixir | #40 | #28 (3%) | ⏳ Planned | tree-sitter-elixir |
 | 25 | Haskell | #29 | #29 (2%) | ⏳ Planned | tree-sitter-haskell |
 
-**Tier 2 Completion: 2/15 (13%)**
+**Tier 2 Completion: 4/15 (27%)**
 
 ### Tier 3: Medium Priority (Config/Data Languages)
 
@@ -91,43 +93,38 @@ Languages ranked by combined popularity from [TIOBE Index](https://www.tiobe.com
 
 ## Implementation Plan
 
-### Phase 1: Complete Tier 1 (2 languages)
+### Phase 1: Complete Tier 1 ✅ DONE
 
-**C++ Parser**
+**C++ Parser** ✅
 ```
 Symbols: class, struct, function, method, namespace, enum, template
 File extensions: .cpp, .hpp, .cc, .hh, .cxx, .hxx
-Complexity: High (templates, namespaces, operator overloading)
 ```
 
-**C Parser**
+**C Parser** ✅
 ```
 Symbols: function, struct, enum, typedef, macro
 File extensions: .c, .h
-Complexity: Medium (preprocessor macros)
 ```
 
-**PHP Parser**
+**PHP Parser** ✅
 ```
 Symbols: class, interface, trait, function, method
 File extensions: .php
-Complexity: Medium
 ```
 
-### Phase 2: High-Value Web Languages
+### Phase 2: High-Value Web Languages (In Progress)
 
-**HTML Parser**
+**HTML Parser** ✅
 ```
-Symbols: element (semantic tags), id, class
+Symbols: element (semantic tags), id
 File extensions: .html, .htm
-Complexity: Low (flat structure)
 ```
 
-**CSS Parser**
+**CSS Parser** ✅
 ```
-Symbols: selector, class, id, keyframe, media-query
-File extensions: .css, .scss, .sass, .less
-Complexity: Medium (nested selectors in SCSS)
+Symbols: class, id, selector, pseudo, media, keyframe
+File extensions: .css
 ```
 
 **SQL Parser**
@@ -208,19 +205,22 @@ Instead of individual packages, consider using [tree-sitter-language-pack](https
 
 | Tier | Total | Done | Remaining | Completion |
 |------|-------|------|-----------|------------|
-| Tier 1 (Critical) | 10 | 9 | 1 | 90% |
-| Tier 2 (High Priority) | 15 | 2 | 13 | 13% |
+| Tier 1 (Critical) | 10 | 10 | 0 | 100% ✅ |
+| Tier 2 (High Priority) | 15 | 4 | 11 | 27% |
 | Tier 3 (Config/Data) | 8 | 0 | 8 | 0% |
 | Tier 4 (Emerging) | 10 | 0 | 10 | 0% |
-| **Total** | **43** | **11** | **32** | **26%** |
+| **Total** | **43** | **14** | **29** | **33%** |
 
 ---
 
 ## Next Actions
 
-1. [x] Implement C++ parser (Tier 1) ✅ Done
-2. [x] Implement C parser (Tier 1) ✅ Done
-3. [ ] Implement PHP parser (Tier 1) - PR #6 under review
-4. [ ] Evaluate tree-sitter-language-pack vs individual packages
-5. [ ] Add HTML/CSS/SQL parsers (Tier 2 web stack)
-6. [ ] Add Bash parser (Tier 2 DevOps)
+1. [x] Implement C++ parser (Tier 1) ✅
+2. [x] Implement C parser (Tier 1) ✅
+3. [x] Implement PHP parser (Tier 1) ✅
+4. [x] Add HTML parser (Tier 2) ✅
+5. [x] Add CSS parser (Tier 2) ✅
+6. [ ] Add Dart parser (Tier 2) - Mobile dev priority
+7. [ ] Add SQL parser (Tier 2) - Database queries
+8. [ ] Add Bash parser (Tier 2) - DevOps scripts
+9. [ ] Evaluate tree-sitter-language-pack vs individual packages


### PR DESCRIPTION
## Summary
- Add `DartParser` using `tree-sitter-language-pack` for Dart/Flutter project support
- Support all major Dart constructs: classes, abstract classes, enums, mixins, extensions
- Support constructors (regular, named, factory), methods, getters, setters
- Support top-level functions and documentation comments (`///`)
- Add comprehensive test suite with 18 tests

## Changes
| File | Description |
|------|-------------|
| `codemap/parsers/dart_parser.py` | New Dart parser (399 lines) |
| `codemap/parsers/__init__.py` | Register DartParser |
| `codemap/tests/fixtures/sample_module.dart` | Test fixture |
| `codemap/tests/test_dart_parser.py` | 18 test cases |
| `docs/plans/language-support-roadmap.md` | Update progress |

## Test plan
- [x] All 18 Dart parser tests pass
- [x] Full test suite passes (337 passed, 1 skipped)
- [x] `get_parser_for_extension('.dart')` returns `DartParser`
- [x] Parser correctly extracts symbols from sample Dart code

🤖 Generated with [Claude Code](https://claude.com/claude-code)