### PR TITLE
feat: Add SQL parser support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ Extract only these symbol types:
 - **CSS**: `class` (.selector), `id` (#selector), `selector` (element), `pseudo` (:root), `media` (@media), `keyframe` (@keyframes)
 - **Markdown**: `section` (H2), `subsection` (H3), `subsubsection` (H4)
 - **YAML**: `key`, `section` (nested mappings), `list`, `item`
+- **SQL**: `table`, `view`, `materialized_view`, `index`, `function`, `trigger`, `type`, `sequence`, `schema`, `database`, `column`
 
 Skip:
 - Variables/constants (too noisy)
@@ -220,6 +221,7 @@ Default include:
 **/*.md
 **/*.yaml
 **/*.yml
+**/*.sql
 ```
 
 Default exclude:
@@ -313,6 +315,9 @@ tree-sitter-cpp>=0.21
 tree-sitter-html>=0.23
 tree-sitter-css>=0.23
 
+# For SQL parsing
+tree-sitter-sql>=0.3
+
 # Dev
 pytest>=7.0
 ```
@@ -345,7 +350,7 @@ codemap watch . &                   # Start watch mode (auto-updates index)
 ```
 
 ### Supported Languages
-Python, TypeScript, JavaScript, Kotlin, Swift, Go, Java, C#, Rust, C, C++, PHP, Dart, HTML, CSS, Markdown, YAML
+Python, TypeScript, JavaScript, Kotlin, Swift, Go, Java, C#, Rust, C, C++, PHP, Dart, SQL, HTML, CSS, Markdown, YAML
 
 ### Workflow
 1. **Start watch mode**: `codemap watch . &` (run once per session)

--- a/codemap/parsers/__init__.py
+++ b/codemap/parsers/__init__.py
@@ -91,6 +91,12 @@ try:
 except ImportError:
     DartParser = None
 
+try:
+    from .sql_parser import SQLParser
+    __all__.append("SQLParser")
+except ImportError:
+    SQLParser = None
+
 
 def get_available_parsers() -> list[type[Parser]]:
     """Return list of all available parser classes."""
@@ -124,6 +130,8 @@ def get_available_parsers() -> list[type[Parser]]:
         parsers.append(PHPParser)
     if DartParser:
         parsers.append(DartParser)
+    if SQLParser:
+        parsers.append(SQLParser)
 
     return parsers
 

--- a/codemap/parsers/sql_parser.py
+++ b/codemap/parsers/sql_parser.py
@@ -1,0 +1,199 @@
+"""SQL parser using tree-sitter with configuration-driven extraction."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .treesitter_base import TreeSitterParser, LanguageConfig, NodeMapping
+from .base import Symbol
+
+# Tree-sitter imports - optional dependency
+try:
+    from tree_sitter import Language, Parser as TSParser, Node
+    TREE_SITTER_AVAILABLE = True
+except ImportError:
+    TREE_SITTER_AVAILABLE = False
+    TSParser = None
+    Node = None
+
+
+# Define SQL language configuration
+SQL_CONFIG = LanguageConfig(
+    name="sql",
+    extensions=[".sql"],
+    grammar_module="sql",
+    node_mappings={
+        # Table definitions
+        "create_table": NodeMapping(
+            symbol_type="table",
+            name_child="object_reference",  # Contains identifier
+            body_child="column_definitions",
+        ),
+        # View definitions
+        "create_view": NodeMapping(
+            symbol_type="view",
+            name_child="object_reference",
+        ),
+        # Materialized view definitions
+        "create_materialized_view": NodeMapping(
+            symbol_type="materialized_view",
+            name_child="object_reference",
+        ),
+        # Index definitions
+        "create_index": NodeMapping(
+            symbol_type="index",
+            name_child="identifier",  # Direct child
+        ),
+        # Function definitions
+        "create_function": NodeMapping(
+            symbol_type="function",
+            name_child="object_reference",
+            signature_child="function_arguments",
+            body_child="function_body",
+        ),
+        # Trigger definitions
+        "create_trigger": NodeMapping(
+            symbol_type="trigger",
+            name_child="object_reference",
+        ),
+        # Type definitions (enums, composites, etc.)
+        "create_type": NodeMapping(
+            symbol_type="type",
+            name_child="object_reference",
+        ),
+        # Sequence definitions
+        "create_sequence": NodeMapping(
+            symbol_type="sequence",
+            name_child="object_reference",
+        ),
+        # Schema definitions
+        "create_schema": NodeMapping(
+            symbol_type="schema",
+            name_child="identifier",  # Direct child
+        ),
+        # Database definitions
+        "create_database": NodeMapping(
+            symbol_type="database",
+            name_child="identifier",  # Direct child
+        ),
+        # Column definitions (for table children)
+        "column_definition": NodeMapping(
+            symbol_type="column",
+            name_child="identifier",
+        ),
+    },
+    comment_types=["comment", "marginalia"],
+)
+
+
+class SQLParser(TreeSitterParser):
+    """Parser for SQL files using tree-sitter.
+
+    Extracts:
+    - Tables (CREATE TABLE)
+    - Views (CREATE VIEW, CREATE MATERIALIZED VIEW)
+    - Indexes (CREATE INDEX)
+    - Functions (CREATE FUNCTION)
+    - Triggers (CREATE TRIGGER)
+    - Types (CREATE TYPE)
+    - Sequences (CREATE SEQUENCE)
+    - Schemas (CREATE SCHEMA)
+    - Databases (CREATE DATABASE)
+    """
+
+    config = SQL_CONFIG
+    extensions = [".sql"]  # Required class attribute
+    language = "sql"  # Required class attribute
+
+    def _extract_symbols(self, node: "Node", source_bytes: bytes) -> list[Symbol]:
+        """Extract symbols from AST node.
+
+        Override to handle SQL's nested statement structure where
+        CREATE statements are wrapped in 'statement' nodes.
+        """
+        symbols = []
+
+        for child in node.children:
+            # Handle direct mappings (e.g., create_table)
+            if child.type in self.config.node_mappings:
+                symbol = self._extract_symbol(child, source_bytes)
+                if symbol:
+                    symbols.append(symbol)
+            # Handle statement wrappers (SQL-specific)
+            elif child.type == "statement":
+                # Extract from inside statement wrapper
+                for stmt_child in child.children:
+                    if stmt_child.type in self.config.node_mappings:
+                        symbol = self._extract_symbol(stmt_child, source_bytes)
+                        if symbol:
+                            symbols.append(symbol)
+
+        return symbols
+
+    def _extract_name(self, node: "Node", mapping: NodeMapping, source_bytes: bytes) -> str:
+        """Extract symbol name from node.
+
+        Override to handle SQL's object_reference -> identifier pattern.
+        """
+        name_children = mapping.name_child
+        if isinstance(name_children, str):
+            name_children = [name_children]
+
+        for child_type in name_children:
+            name_node = self._find_child(node, child_type)
+            if name_node:
+                # If this is an object_reference, get the identifier inside it
+                if name_node.type == "object_reference":
+                    identifier = self._find_child(name_node, "identifier")
+                    if identifier:
+                        return self._get_node_text(identifier, source_bytes)
+                return self._get_node_text(name_node, source_bytes)
+
+        return "<anonymous>"
+
+    def _extract_children(self, body_node: "Node", source_bytes: bytes) -> list[Symbol]:
+        """Extract child symbols from a body node.
+
+        Override to handle column_definitions structure where columns
+        are direct children of the body node.
+        """
+        children = []
+        for child in body_node.children:
+            if child.type in self.config.node_mappings:
+                symbol = self._extract_symbol(child, source_bytes)
+                if symbol:
+                    children.append(symbol)
+        return children
+
+    def _extract_signature(self, node: "Node", mapping: NodeMapping, source_bytes: bytes) -> Optional[str]:
+        """Extract function signature.
+
+        Override to extract parameter types from function_arguments.
+        """
+        if not mapping.signature_child:
+            return None
+
+        sig_node = self._find_child(node, mapping.signature_child)
+        if sig_node:
+            sig_text = self._get_node_text(sig_node, source_bytes)
+
+            # Try to get return type
+            returns_node = self._find_child(node, "keyword_returns")
+            if returns_node:
+                # Find the type node after RETURNS keyword
+                found_returns = False
+                for child in node.children:
+                    if found_returns and child.type not in ("keyword_returns",):
+                        # This should be the return type
+                        if child.type == "int":
+                            sig_text += " -> INT"
+                        elif child.type in ("varchar", "char", "text"):
+                            sig_text += f" -> {self._get_node_text(child, source_bytes).upper()}"
+                        elif child.type == "identifier":
+                            sig_text += f" -> {self._get_node_text(child, source_bytes)}"
+                        break
+                    if child.type == "keyword_returns":
+                        found_returns = True
+
+            return sig_text if sig_text != "()" else None
+        return None

--- a/codemap/tests/fixtures/sample_database.sql
+++ b/codemap/tests/fixtures/sample_database.sql
@@ -1,0 +1,82 @@
+-- Sample SQL file demonstrating various SQL constructs
+-- for CodeMap SQL parser testing
+
+-- Users table with various column types
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(50) NOT NULL UNIQUE,
+    email VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP,
+    is_active BOOLEAN DEFAULT true
+);
+
+-- Orders table with foreign key
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL,
+    total_amount DECIMAL(10, 2) NOT NULL,
+    status VARCHAR(20) DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Simple view
+CREATE VIEW active_users AS
+SELECT id, username, email, created_at
+FROM users
+WHERE is_active = true;
+
+-- Materialized view for reporting
+CREATE MATERIALIZED VIEW user_order_summary AS
+SELECT
+    u.id AS user_id,
+    u.username,
+    COUNT(o.id) AS order_count,
+    COALESCE(SUM(o.total_amount), 0) AS total_spent
+FROM users u
+LEFT JOIN orders o ON u.id = o.user_id
+GROUP BY u.id, u.username;
+
+-- Index for email lookups
+CREATE INDEX idx_users_email ON users(email);
+
+-- Composite index
+CREATE INDEX idx_orders_user_status ON orders(user_id, status);
+
+-- Function to get user by email
+CREATE FUNCTION get_user_by_email(user_email VARCHAR) RETURNS users AS $$
+SELECT * FROM users WHERE email = user_email LIMIT 1;
+$$ LANGUAGE SQL;
+
+-- Function with multiple parameters
+CREATE FUNCTION calculate_discount(amount DECIMAL, discount_rate DECIMAL) RETURNS DECIMAL AS $$
+BEGIN
+    RETURN amount * (1 - discount_rate);
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger function
+CREATE FUNCTION update_timestamp() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger for automatic timestamp update
+CREATE TRIGGER users_update_timestamp
+BEFORE UPDATE ON users
+FOR EACH ROW EXECUTE FUNCTION update_timestamp();
+
+-- Enum type for order status
+CREATE TYPE order_status AS ENUM ('pending', 'processing', 'shipped', 'delivered', 'cancelled');
+
+-- Sequence for custom IDs
+CREATE SEQUENCE invoice_number_seq START WITH 1000 INCREMENT BY 1;
+
+-- Schema for analytics
+CREATE SCHEMA analytics;
+
+-- Database creation (usually in separate script)
+CREATE DATABASE ecommerce_db;

--- a/codemap/tests/test_sql_parser.py
+++ b/codemap/tests/test_sql_parser.py
@@ -1,0 +1,246 @@
+"""Tests for the SQL parser."""
+
+import os
+
+import pytest
+
+# Skip if grammar not installed
+pytest.importorskip("tree_sitter_sql")
+
+from codemap.parsers.sql_parser import SQLParser
+
+
+class TestSQLParser:
+    """Tests for SQLParser class."""
+
+    @pytest.fixture
+    def parser(self):
+        return SQLParser()
+
+    def test_parse_table(self, parser):
+        """Test parsing CREATE TABLE statements."""
+        source = """
+        CREATE TABLE users (
+            id INT PRIMARY KEY,
+            name VARCHAR(255) NOT NULL
+        );
+        """
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "users"
+        assert symbols[0].type == "table"
+        # Check column children
+        assert symbols[0].children is not None
+        assert len(symbols[0].children) == 2
+        assert symbols[0].children[0].name == "id"
+        assert symbols[0].children[0].type == "column"
+        assert symbols[0].children[1].name == "name"
+        assert symbols[0].children[1].type == "column"
+
+    def test_parse_view(self, parser):
+        """Test parsing CREATE VIEW statements."""
+        source = """
+        CREATE VIEW active_users AS
+        SELECT * FROM users WHERE active = true;
+        """
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "active_users"
+        assert symbols[0].type == "view"
+
+    def test_parse_materialized_view(self, parser):
+        """Test parsing CREATE MATERIALIZED VIEW statements."""
+        source = """
+        CREATE MATERIALIZED VIEW user_summary AS
+        SELECT COUNT(*) AS total FROM users;
+        """
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "user_summary"
+        assert symbols[0].type == "materialized_view"
+
+    def test_parse_index(self, parser):
+        """Test parsing CREATE INDEX statements."""
+        source = """CREATE INDEX idx_users_email ON users(email);"""
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "idx_users_email"
+        assert symbols[0].type == "index"
+
+    def test_parse_function(self, parser):
+        """Test parsing CREATE FUNCTION statements."""
+        source = """
+        CREATE FUNCTION get_count() RETURNS INT AS $$
+        BEGIN
+            RETURN 1;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "get_count"
+        assert symbols[0].type == "function"
+        assert symbols[0].signature is not None
+        assert "INT" in symbols[0].signature
+
+    def test_parse_function_with_parameters(self, parser):
+        """Test parsing functions with parameters."""
+        source = """
+        CREATE FUNCTION add_numbers(a INT, b INT) RETURNS INT AS $$
+        BEGIN
+            RETURN a + b;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "add_numbers"
+        assert symbols[0].type == "function"
+        assert symbols[0].signature is not None
+        # Check signature includes parameters
+        assert "a" in symbols[0].signature or "INT" in symbols[0].signature
+
+    def test_parse_trigger(self, parser):
+        """Test parsing CREATE TRIGGER statements."""
+        source = """
+        CREATE TRIGGER update_timestamp
+        BEFORE UPDATE ON users
+        FOR EACH ROW EXECUTE FUNCTION update_ts();
+        """
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "update_timestamp"
+        assert symbols[0].type == "trigger"
+
+    def test_parse_type(self, parser):
+        """Test parsing CREATE TYPE statements."""
+        source = """CREATE TYPE status_enum AS ENUM ('active', 'inactive');"""
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "status_enum"
+        assert symbols[0].type == "type"
+
+    def test_parse_sequence(self, parser):
+        """Test parsing CREATE SEQUENCE statements."""
+        source = """CREATE SEQUENCE user_id_seq START WITH 1 INCREMENT BY 1;"""
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "user_id_seq"
+        assert symbols[0].type == "sequence"
+
+    def test_parse_schema(self, parser):
+        """Test parsing CREATE SCHEMA statements."""
+        source = """CREATE SCHEMA analytics;"""
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "analytics"
+        assert symbols[0].type == "schema"
+
+    def test_parse_database(self, parser):
+        """Test parsing CREATE DATABASE statements."""
+        source = """CREATE DATABASE test_db;"""
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "test_db"
+        assert symbols[0].type == "database"
+
+    def test_parse_multiple_statements(self, parser):
+        """Test parsing multiple SQL statements."""
+        source = """
+        CREATE TABLE users (id INT);
+        CREATE VIEW active_users AS SELECT * FROM users;
+        CREATE INDEX idx_users ON users(id);
+        """
+        symbols = parser.parse(source)
+        assert len(symbols) == 3
+        types = [s.type for s in symbols]
+        assert "table" in types
+        assert "view" in types
+        assert "index" in types
+
+    def test_parse_with_comments(self, parser):
+        """Test parsing SQL with comments."""
+        source = """
+        -- User table for storing user data
+        CREATE TABLE users (
+            id INT PRIMARY KEY
+        );
+        """
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "users"
+        # Note: comment extraction may vary based on tree-sitter grammar
+
+    def test_parse_empty_source(self, parser):
+        """Test parsing empty source."""
+        symbols = parser.parse("")
+        assert symbols == []
+
+    def test_parse_only_comments(self, parser):
+        """Test parsing source with only comments."""
+        source = """
+        -- This is a comment
+        /* Multi-line
+           comment */
+        """
+        symbols = parser.parse(source)
+        assert symbols == []
+
+    def test_parse_fixture_file(self, parser):
+        """Test parsing the fixture file."""
+        fixture_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "sample_database.sql"
+        )
+        with open(fixture_path, "r") as f:
+            source = f.read()
+        symbols = parser.parse(source, fixture_path)
+        # Should have multiple symbols
+        assert len(symbols) >= 10
+        # Check for expected types
+        types = [s.type for s in symbols]
+        assert "table" in types
+        assert "view" in types
+        assert "index" in types
+        assert "function" in types
+        assert "trigger" in types
+        assert "type" in types
+        assert "sequence" in types
+        assert "schema" in types
+
+    def test_extensions(self, parser):
+        """Test that parser reports correct extensions."""
+        assert ".sql" in parser.extensions
+
+    def test_language(self, parser):
+        """Test that parser reports correct language."""
+        assert parser.language == "sql"
+
+    def test_line_numbers(self, parser):
+        """Test that line numbers are correctly reported."""
+        source = """CREATE TABLE test (
+    id INT
+);"""
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        # Should span multiple lines
+        assert symbols[0].lines[0] == 1
+        assert symbols[0].lines[1] >= 3
+
+    def test_table_with_many_columns(self, parser):
+        """Test parsing table with many columns."""
+        source = """
+        CREATE TABLE products (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(255),
+            description TEXT,
+            price DECIMAL(10, 2),
+            quantity INT,
+            category_id INT,
+            created_at TIMESTAMP
+        );
+        """
+        symbols = parser.parse(source)
+        assert len(symbols) == 1
+        assert symbols[0].name == "products"
+        assert symbols[0].children is not None
+        assert len(symbols[0].children) == 7

--- a/docs/plans/language-support-roadmap.md
+++ b/docs/plans/language-support-roadmap.md
@@ -4,13 +4,13 @@
 
 ## Current Status
 
-**Supported Languages (16):**
+**Supported Languages (18):**
 - Python (stdlib ast)
 - TypeScript, JavaScript (tree-sitter)
-- Kotlin, Swift (tree-sitter)
+- Kotlin, Swift, Dart (tree-sitter)
 - Go, Java, C#, Rust (tree-sitter)
 - C, C++ (tree-sitter)
-- PHP (tree-sitter)
+- PHP, SQL (tree-sitter)
 - HTML, CSS (tree-sitter)
 - Markdown, YAML (custom parsers)
 
@@ -39,7 +39,7 @@ Languages ranked by combined popularity from [TIOBE Index](https://www.tiobe.com
 
 | Rank | Language | TIOBE 2025 | Stack Overflow | Status | Package |
 |------|----------|------------|----------------|--------|---------|
-| 11 | SQL | - | #4 (52%) | ⏳ Planned | tree-sitter-sql |
+| 11 | SQL | - | #4 (52%) | ✅ Done | tree-sitter-sql |
 | 12 | HTML | - | #2 (54%) | ✅ Done | tree-sitter-html |
 | 13 | CSS/SCSS | - | #6 (42%) | ✅ Done | tree-sitter-css |
 | 14 | Bash/Shell | - | #7 (33%) | ⏳ Planned | tree-sitter-bash |
@@ -47,7 +47,7 @@ Languages ranked by combined popularity from [TIOBE Index](https://www.tiobe.com
 | 16 | Kotlin | #15 | #15 (9%) | ✅ Done | tree-sitter-kotlin |
 | 17 | Swift | #16 | #16 (6%) | ✅ Done | tree-sitter-swift |
 | 18 | Lua | #26 | #21 (4%) | ⏳ Planned | tree-sitter-lua |
-| 19 | Dart | #20 | #18 (6%) | ⏳ Planned | tree-sitter-dart |
+| 19 | Dart | #20 | #18 (6%) | ✅ Done | tree-sitter-dart |
 | 20 | R | #10 | #22 (4%) | ⏳ Planned | tree-sitter-r |
 | 21 | Scala | #28 | #24 (3%) | ⏳ Planned | tree-sitter-scala |
 | 22 | Perl | #11 | #26 (2%) | ⏳ Planned | tree-sitter-perl |
@@ -55,7 +55,7 @@ Languages ranked by combined popularity from [TIOBE Index](https://www.tiobe.com
 | 24 | Elixir | #40 | #28 (3%) | ⏳ Planned | tree-sitter-elixir |
 | 25 | Haskell | #29 | #29 (2%) | ⏳ Planned | tree-sitter-haskell |
 
-**Tier 2 Completion: 4/15 (27%)**
+**Tier 2 Completion: 6/15 (40%)**
 
 ### Tier 3: Medium Priority (Config/Data Languages)
 
@@ -127,11 +127,10 @@ Symbols: class, id, selector, pseudo, media, keyframe
 File extensions: .css
 ```
 
-**SQL Parser**
+**SQL Parser** ✅
 ```
-Symbols: table, view, function, procedure, trigger
+Symbols: table, view, materialized_view, index, function, trigger, type, sequence, schema, database, column
 File extensions: .sql
-Complexity: Medium (dialect variations)
 ```
 
 ### Phase 3: Shell & DevOps
@@ -206,10 +205,10 @@ Instead of individual packages, consider using [tree-sitter-language-pack](https
 | Tier | Total | Done | Remaining | Completion |
 |------|-------|------|-----------|------------|
 | Tier 1 (Critical) | 10 | 10 | 0 | 100% ✅ |
-| Tier 2 (High Priority) | 15 | 4 | 11 | 27% |
+| Tier 2 (High Priority) | 15 | 6 | 9 | 40% |
 | Tier 3 (Config/Data) | 8 | 0 | 8 | 0% |
 | Tier 4 (Emerging) | 10 | 0 | 10 | 0% |
-| **Total** | **43** | **14** | **29** | **33%** |
+| **Total** | **43** | **16** | **27** | **37%** |
 
 ---
 
@@ -220,7 +219,7 @@ Instead of individual packages, consider using [tree-sitter-language-pack](https
 3. [x] Implement PHP parser (Tier 1) ✅
 4. [x] Add HTML parser (Tier 2) ✅
 5. [x] Add CSS parser (Tier 2) ✅
-6. [ ] Add Dart parser (Tier 2) - Mobile dev priority
-7. [ ] Add SQL parser (Tier 2) - Database queries
+6. [x] Add Dart parser (Tier 2) - Mobile dev priority ✅
+7. [x] Add SQL parser (Tier 2) - Database queries ✅
 8. [ ] Add Bash parser (Tier 2) - DevOps scripts
 9. [ ] Evaluate tree-sitter-language-pack vs individual packages


### PR DESCRIPTION
## Summary
- Add SQLParser using tree-sitter for `.sql` files
- Extract 11 symbol types: tables, views, materialized views, indexes, functions, triggers, types, sequences, schemas, databases, and columns
- Tables include column definitions as nested children
- Functions include parameter signatures and return types

## Symbol Types Extracted

| Symbol Type | SQL Construct |
|------------|---------------|
| `table` | CREATE TABLE |
| `view` | CREATE VIEW |
| `materialized_view` | CREATE MATERIALIZED VIEW |
| `index` | CREATE INDEX |
| `function` | CREATE FUNCTION |
| `trigger` | CREATE TRIGGER |
| `type` | CREATE TYPE |
| `sequence` | CREATE SEQUENCE |
| `schema` | CREATE SCHEMA |
| `database` | CREATE DATABASE |
| `column` | Column definitions (children of tables) |

## Test plan
- [x] 20 unit tests covering all symbol types
- [x] Fixture file with comprehensive SQL examples
- [x] All tests passing

## Files Changed
- `codemap/parsers/sql_parser.py` - New SQL parser
- `codemap/parsers/__init__.py` - Register SQLParser
- `codemap/tests/test_sql_parser.py` - Test suite
- `codemap/tests/fixtures/sample_database.sql` - Test fixture
- `docs/plans/language-support-roadmap.md` - Mark SQL as done
- `CLAUDE.md` - Add SQL to supported languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)