### PR TITLE
feat: Add CommonJS function assignment parsing

### DIFF
--- a/codemap/tests/fixtures/commonjs_test.js
+++ b/codemap/tests/fixtures/commonjs_test.js
@@ -1,0 +1,38 @@
+/**
+ * Test file for CommonJS pattern support.
+ */
+
+// Named function expression assignment
+app.handle = function handle(req, res) {
+  console.log('test');
+};
+
+// Another named function
+res.json = function json(obj) {
+  return obj;
+};
+
+// Arrow function assignment
+app.middleware = (req, res, next) => {
+  next();
+};
+
+// Async function expression
+app.fetch = async function fetch(url) {
+  return await fetch(url);
+};
+
+// Module exports pattern
+module.exports.helper = function helper(data) {
+  return data;
+};
+
+// Prototype assignment
+Response.prototype.send = function send(body) {
+  return body;
+};
+
+// Anonymous function (uses property name "anon" for indexing)
+app.anon = function() {
+  return null;
+};


### PR DESCRIPTION
## Summary
- Parse CommonJS-style function assignments in JavaScript files
- Extract functions from patterns like `app.method = function() {}`
- Support async functions and arrow functions

## Patterns Supported
```javascript
app.method = function() {}
obj.prop = () => {}
module.exports.foo = function() {}
exports.bar = async function() {}
```

## Test plan
- [x] Add test fixture with CommonJS patterns
- [x] Add tests for CommonJS function extraction
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)