### PR TITLE
fix: Traverse C# namespace declarations for symbol extraction

### DIFF
--- a/codemap/parsers/csharp_parser.py
+++ b/codemap/parsers/csharp_parser.py
@@ -17,6 +17,11 @@ CSHARP_CONFIG = LanguageConfig(
     name="csharp",
     extensions=[".cs"],
     grammar_module="c_sharp",
+    container_types=[
+        "namespace_declaration",              # namespace Foo { ... }
+        "file_scoped_namespace_declaration",  # namespace Foo; (C# 10+)
+        "declaration_list",                   # { ... } block containing declarations
+    ],
     node_mappings={
         "class_declaration": NodeMapping(
             symbol_type="class",


### PR DESCRIPTION
## Summary
- Add generic `container_types` field to `LanguageConfig` in `treesitter_base.py`
- Apply to C# parser: `namespace_declaration`, `file_scoped_namespace_declaration`, `declaration_list`
- Add 4 new namespace-specific tests to C# parser test suite
- Add mandatory real-world project validation step to `docs/adding-language-support.md`

## Impact
| Metric | Before | After |
|--------|--------|-------|
| Symbols extracted (real codebase) | 1,202 | 31,004 |
| Symbol coverage | 0.8% | 98.6% |
| Files with symbols | 32 | 4,110 |

## Generic solution
The `container_types` config field can be reused by any language that wraps declarations in non-symbol containers. Other languages can benefit by simply adding container types to their config — no code override needed.

## Test plan
- [x] 4 new namespace tests (classic, file-scoped, nested, mixed types)
- [x] All 13 C# tests pass
- [x] All 8 base treesitter tests pass (no regression)

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)