### PR TITLE
fix: distinguish Swift structs from classes

### DIFF
--- a/codemap/parsers/swift_parser.py
+++ b/codemap/parsers/swift_parser.py
@@ -16,7 +16,7 @@ def get_swift_class_type(node) -> str:
         if child.type == "extension":
             return "class"
         if child.type == "struct":
-            return "class"
+            return "struct"
         if child.type == "class":
             return "class"
     return "class"

--- a/codemap/tests/test_swift_parser.py
+++ b/codemap/tests/test_swift_parser.py
@@ -26,7 +26,7 @@ struct User {
 
         assert len(symbols) == 1
         assert symbols[0].name == "User"
-        assert symbols[0].type == "class"
+        assert symbols[0].type == "struct"
 
     def test_parse_class(self, parser):
         source = '''


### PR DESCRIPTION
## Summary
Fixes #23

One-line fix: `get_swift_class_type()` now returns `"struct"` for struct declarations instead of `"class"`.

### Before
```
codemap stats → class: 257 (includes structs)
```

### After
```
codemap stats → class: ~195, struct: ~62 (correctly separated)
```

## Test plan
- [x] All 13 Swift parser tests pass (updated struct assertion)
- [x] Full test suite passes (422 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)