### PR TITLE
Add multiple file support to `show` command and fix Windows path separators

### DIFF
--- a/codemap/__init__.py
+++ b/codemap/__init__.py
@@ -1,3 +1,3 @@
 """CodeMap - LLM-friendly codebase indexer."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/codemap/core/indexer.py
+++ b/codemap/core/indexer.py
@@ -264,11 +264,11 @@ class Indexer:
             logger.warning(f"Syntax error in {filepath}: {e}")
             symbols = []
 
-        # Get relative path
+        # Get relative path (always use forward slashes for consistency)
         try:
-            rel_path = str(filepath.relative_to(self.root))
+            rel_path = filepath.relative_to(self.root).as_posix()
         except ValueError:
-            rel_path = str(filepath)
+            rel_path = filepath.as_posix()
 
         # Update map store
         self.map_store.update_file(
@@ -312,9 +312,9 @@ class Indexer:
         if not filepath.exists():
             # File was deleted, remove from index
             try:
-                rel_path = str(filepath.relative_to(self.root))
+                rel_path = filepath.relative_to(self.root).as_posix()
             except ValueError:
-                rel_path = str(filepath)
+                rel_path = filepath.as_posix()
 
             removed = self.map_store.remove_file(rel_path)
             self.map_store.update_stats()
@@ -328,7 +328,7 @@ class Indexer:
         # Re-index the file
         try:
             old_entry = self.map_store.get_file(
-                str(filepath.relative_to(self.root))
+                filepath.relative_to(self.root).as_posix()
             )
             old_symbol_count = 0
             if old_entry:
@@ -407,9 +407,9 @@ class Indexer:
         """
         filepath = Path(filepath)
         try:
-            rel_path = str(filepath.relative_to(self.root))
+            rel_path = filepath.relative_to(self.root).as_posix()
         except ValueError:
-            rel_path = str(filepath)
+            rel_path = filepath.as_posix()
 
         entry = self.map_store.get_file(rel_path)
         if not entry:

--- a/codemap/core/map_store.py
+++ b/codemap/core/map_store.py
@@ -280,7 +280,7 @@ class MapStore:
         """
         # Determine which directory this file belongs to
         path = Path(rel_path)
-        directory = str(path.parent) if path.parent != Path(".") else ""
+        directory = path.parent.as_posix() if path.parent != Path(".") else ""
         filename = path.name
 
         # Load or create the directory map
@@ -309,7 +309,7 @@ class MapStore:
             True if file was removed, False if it didn't exist.
         """
         path = Path(rel_path)
-        directory = str(path.parent) if path.parent != Path(".") else ""
+        directory = path.parent.as_posix() if path.parent != Path(".") else ""
         filename = path.name
 
         dir_map = self._load_dir_map(directory)
@@ -345,7 +345,7 @@ class MapStore:
             FileEntry or None if not found.
         """
         path = Path(rel_path)
-        directory = str(path.parent) if path.parent != Path(".") else ""
+        directory = path.parent.as_posix() if path.parent != Path(".") else ""
         filename = path.name
 
         dir_map = self._load_dir_map(directory)

--- a/codemap/core/watcher.py
+++ b/codemap/core/watcher.py
@@ -72,7 +72,7 @@ class CodemapEventHandler(FileSystemEventHandler):
 
             # Skip .codemap directory
             try:
-                rel_path = str(filepath.relative_to(self.root))
+                rel_path = filepath.relative_to(self.root).as_posix()
             except ValueError:
                 return False
 
@@ -145,7 +145,7 @@ class CodemapEventHandler(FileSystemEventHandler):
             filepath = Path(event.src_path)
             if get_language(filepath) is not None:
                 try:
-                    rel_path = str(filepath.relative_to(self.root))
+                    rel_path = filepath.relative_to(self.root).as_posix()
                     # Skip .codemap directory
                     if rel_path.startswith(".codemap"):
                         return
@@ -162,7 +162,7 @@ class CodemapEventHandler(FileSystemEventHandler):
             src_path = Path(event.src_path)
             if get_language(src_path) is not None:
                 try:
-                    rel_path = str(src_path.relative_to(self.root))
+                    rel_path = src_path.relative_to(self.root).as_posix()
                     # Skip .codemap directory
                     if rel_path.startswith(".codemap"):
                         return
@@ -229,9 +229,9 @@ class CodeMapWatcher:
             event_type: Type of change.
         """
         try:
-            rel_path = str(filepath.relative_to(self.root))
+            rel_path = filepath.relative_to(self.root).as_posix()
         except ValueError:
-            rel_path = str(filepath)
+            rel_path = filepath.as_posix()
 
         try:
             if event_type == "deleted":

--- a/codemap/tests/test_file_utils.py
+++ b/codemap/tests/test_file_utils.py
@@ -2,7 +2,12 @@
 
 import pytest
 from pathlib import Path
-from codemap.utils.file_utils import get_language, _get_extensions_for_languages
+from codemap.utils.file_utils import (
+    get_language,
+    _get_extensions_for_languages,
+    is_glob_pattern,
+    match_files_to_pattern,
+)
 
 
 class TestLanguageDetection:
@@ -30,3 +35,77 @@ class TestLanguageDetection:
         expected = [".cs", ".dart", ".go", ".java", ".rs", ".sql"]
         for ext in expected:
             assert ext in extensions, f"{ext} not returned for its language"
+
+
+class TestGlobPatternDetection:
+    """Test glob pattern detection."""
+
+    def test_is_glob_pattern_with_star(self):
+        """Test detection of * character."""
+        assert is_glob_pattern("*.py") is True
+        assert is_glob_pattern("**/*.py") is True
+        assert is_glob_pattern("src/*") is True
+        assert is_glob_pattern("src/**/*.ts") is True
+
+    def test_is_glob_pattern_with_question(self):
+        """Test detection of ? character."""
+        assert is_glob_pattern("file?.py") is True
+        assert is_glob_pattern("test?.ts") is True
+
+    def test_is_glob_pattern_literal_path(self):
+        """Test that literal paths are not detected as globs."""
+        assert is_glob_pattern("src/main.py") is False
+        assert is_glob_pattern("main.py") is False
+        assert is_glob_pattern("path/to/file.ts") is False
+
+
+class TestMatchFilesToPattern:
+    """Test glob pattern matching against file lists."""
+
+    def test_match_simple_extension_pattern(self):
+        """Test matching *.ext pattern."""
+        files = ["main.py", "utils.py", "main.ts", "README.md"]
+        matches = match_files_to_pattern(iter(files), "*.py")
+        assert matches == ["main.py", "utils.py"]
+
+    def test_match_recursive_pattern(self):
+        """Test matching **/*.ext pattern."""
+        files = ["main.py", "src/app.py", "src/components/button.py", "README.md"]
+        matches = match_files_to_pattern(iter(files), "**/*.py")
+        assert "main.py" in matches
+        assert "src/app.py" in matches
+        assert "src/components/button.py" in matches
+        assert "README.md" not in matches
+
+    def test_match_directory_pattern(self):
+        """Test matching src/*.py pattern (fnmatch behavior)."""
+        files = ["main.py", "src/app.py", "src/deep/utils.py", "lib/app.py"]
+        matches = match_files_to_pattern(iter(files), "src/*.py")
+        # Note: fnmatch * matches any characters including /
+        assert "src/app.py" in matches
+        assert "src/deep/utils.py" in matches
+        assert "main.py" not in matches
+        assert "lib/app.py" not in matches
+
+    def test_match_no_matches(self):
+        """Test when no files match the pattern."""
+        files = ["main.py", "utils.py"]
+        matches = match_files_to_pattern(iter(files), "*.ts")
+        assert matches == []
+
+    def test_match_results_are_sorted(self):
+        """Test that results are returned sorted."""
+        files = ["z.py", "a.py", "m.py"]
+        matches = match_files_to_pattern(iter(files), "*.py")
+        assert matches == ["a.py", "m.py", "z.py"]
+
+    def test_match_backslash_normalization(self):
+        """Test that Windows-style paths work with Unix-style patterns."""
+        files = ["src\\main.py", "src\\utils.py"]
+        matches = match_files_to_pattern(iter(files), "src/*.py")
+        assert len(matches) == 2
+
+    def test_match_empty_file_list(self):
+        """Test matching against empty file list."""
+        matches = match_files_to_pattern(iter([]), "*.py")
+        assert matches == []

--- a/codemap/utils/file_utils.py
+++ b/codemap/utils/file_utils.py
@@ -136,6 +136,44 @@ def _match_parts(path_parts: list[str], pattern_parts: list[str]) -> bool:
         return False
 
 
+def is_glob_pattern(path: str) -> bool:
+    """Check if a path string contains glob pattern characters.
+
+    Args:
+        path: Path string to check.
+
+    Returns:
+        True if the path contains glob characters (* or ?).
+    """
+    return "*" in path or "?" in path
+
+
+def match_files_to_pattern(
+    indexed_files: Iterator[str],
+    pattern: str,
+) -> list[str]:
+    """Match indexed files against a glob pattern.
+
+    Args:
+        indexed_files: Iterator of relative file paths from the index.
+        pattern: Glob pattern to match (e.g., '**/*.py', 'src/*.ts').
+
+    Returns:
+        List of matching file paths, sorted alphabetically.
+    """
+    # Normalize pattern separators
+    pattern = pattern.replace("\\", "/")
+
+    matches = []
+    for filepath in indexed_files:
+        # Normalize filepath separators
+        normalized = filepath.replace("\\", "/")
+        if _match_glob_pattern(normalized, pattern):
+            matches.append(filepath)
+
+    return sorted(matches)
+
+
 def _get_extensions_for_languages(languages: list[str]) -> list[str]:
     """Get file extensions for given languages.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codemap"
-version = "1.2.0"
+version = "1.3.0"
 description = "LLM-friendly codebase indexer - reduces token consumption by enabling targeted line-range reads"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Summary

This PR adds support for showing multiple files with the `show` command and ensures all paths use UNIX-style forward slashes consistently across all platforms.

### Problem

1. **`show` command only accepted single files**: Running `codemap show **/Program.cs` resulted in "unexpected extra arguments" because the shell expands globs before the CLI receives them, and the command only accepted one filepath argument.

2. **Windows path separators leaked into output and JSON files**: On Windows, paths were stored and displayed with backslashes (e.g., `src\utils\helper.py`), causing inconsistent behavior and failing tests like `test_get_all_files`.

### Solution

#### Multiple file support for `show` command

- Changed `@click.argument("filepath")` to `@click.argument("filepaths", nargs=-1, required=True)`
- Added detection of quoted glob patterns (e.g., `"**/*.py"`) for internal matching against indexed files
- Shell-expanded paths (multiple literal paths) are now handled correctly
- Added summary output showing count of files displayed and any not-indexed files

**New usage examples:**
```bash
codemap show codemap/cli.py                 # Single file (backward compatible)
codemap show */tests/*.py */utils/*.py      # Shell-expanded globs
codemap show "**/*.py"                      # Quoted glob pattern
```

#### UNIX path separator consistency
Changed all `str(path)` and `str(path.relative_to(...))` calls to use `.as_posix()`:

- **indexer.py**: 4 locations where relative paths are generated
- **map_store.py**: 3 locations where directory paths are extracted
- **watcher.py**: 4 locations where file change events generate paths
- **cli.py**: Normalize shell-expanded paths with .replace("\\", "/")