### PR TITLE
feat: speed up init and update for large codebases

### DIFF
--- a/codemap/cli.py
+++ b/codemap/cli.py
@@ -85,6 +85,20 @@ def update(filepath: str | None, update_all: bool):
     try:
         indexer = Indexer.load_existing()
 
+        if not update_all and not filepath:
+            click.echo("Please specify a file path or use --all", err=True)
+            sys.exit(1)
+
+        migration = indexer.migrate_missing_file_metadata()
+        if migration["migrated"]:
+            click.echo(f"Migrated metadata for {migration['migrated']} files")
+        if migration["errors"]:
+            click.echo(click.style(f"Warnings ({len(migration['errors'])}):", fg="yellow"))
+            for stale_path, error in migration["errors"][:5]:
+                click.echo(f"  - {stale_path}: {error}")
+            if len(migration["errors"]) > 5:
+                click.echo(f"  ... and {len(migration['errors']) - 5} more")
+
         if update_all:
             result = indexer.update_all_stale()
             click.echo(f"Updated {result['updated']} files")
@@ -92,15 +106,12 @@ def update(filepath: str | None, update_all: bool):
                 click.echo(click.style(f"Errors ({len(result['errors'])}):", fg="red"))
                 for filepath, error in result["errors"]:
                     click.echo(f"  - {filepath}: {error}")
-        elif filepath:
+        else:
             result = indexer.update_file(filepath)
             if result.get("removed"):
                 click.echo(f"Removed {filepath} from index")
             else:
                 click.echo(f"Updated {filepath} ({result['symbols_changed']} symbols changed)")
-        else:
-            click.echo("Please specify a file path or use --all", err=True)
-            sys.exit(1)
 
     except FileNotFoundError as e:
         click.echo(click.style(f"Error: {e}", fg="red"), err=True)

--- a/codemap/core/indexer.py
+++ b/codemap/core/indexer.py
@@ -9,9 +9,9 @@ from typing import Optional
 from ..parsers.base import Parser, Symbol
 from ..parsers.python_parser import PythonParser
 from ..utils.config import Config, load_config
-from ..utils.file_utils import count_lines, discover_files, get_language
-from .hasher import hash_file
-from .map_store import MapStore
+from ..utils.file_utils import discover_files, get_language
+from .hasher import hash_content, hash_file
+from .map_store import FileEntry, MapStore
 
 logger = logging.getLogger(__name__)
 
@@ -250,12 +250,7 @@ class Indexer:
             logger.debug(f"No parser for language {language}")
             return []
 
-        # Read file content
-        try:
-            content = filepath.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
-            # Try with errors='replace' for non-UTF-8 files
-            content = filepath.read_text(encoding="utf-8", errors="replace")
+        content, file_hash, line_count, file_size, mtime_ns = self._read_file_data(filepath)
 
         # Parse symbols
         try:
@@ -273,13 +268,91 @@ class Indexer:
         # Update map store
         self.map_store.update_file(
             rel_path=rel_path,
-            hash=hash_file(filepath),
+            hash=file_hash,
             language=language,
-            lines=count_lines(filepath),
+            lines=line_count,
             symbols=symbols,
+            size=file_size,
+            mtime_ns=mtime_ns,
         )
 
         return symbols
+
+    def _read_file_data(self, filepath: Path) -> tuple[str, str, int, int, int]:
+        """Read file bytes once and derive the metadata needed for indexing."""
+        raw = filepath.read_bytes()
+        try:
+            content = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            content = raw.decode("utf-8", errors="replace")
+
+        stat = filepath.stat()
+        return (
+            content,
+            hash_content(raw),
+            self._count_lines_from_content(content),
+            stat.st_size,
+            stat.st_mtime_ns,
+        )
+
+    @staticmethod
+    def _count_lines_from_content(content: str) -> int:
+        """Count lines without re-reading the file from disk."""
+        if not content:
+            return 0
+        return content.count("\n") + (0 if content.endswith("\n") else 1)
+
+    @staticmethod
+    def _metadata_matches(entry: FileEntry, filepath: Path) -> bool:
+        """Check whether a file's stat metadata still matches the indexed entry."""
+        if entry.size is None or entry.mtime_ns is None:
+            return False
+
+        stat = filepath.stat()
+        return entry.size == stat.st_size and entry.mtime_ns == stat.st_mtime_ns
+
+    def migrate_missing_file_metadata(self) -> dict:
+        """Backfill stat metadata for indexed files created by older codemap versions."""
+        migrated = 0
+        missing = 0
+        stale = 0
+        errors = []
+
+        for rel_path, entry in self.map_store.get_all_files():
+            if entry.size is not None and entry.mtime_ns is not None:
+                continue
+
+            filepath = self.root / rel_path
+            if not filepath.exists():
+                missing += 1
+                continue
+
+            try:
+                current_hash = hash_file(filepath)
+                if current_hash != entry.hash:
+                    stale += 1
+                    continue
+
+                stat = filepath.stat()
+                if self.map_store.update_file_metadata(
+                    rel_path,
+                    size=stat.st_size,
+                    mtime_ns=stat.st_mtime_ns,
+                ):
+                    migrated += 1
+            except Exception as e:
+                logger.warning(f"Failed to migrate metadata for {filepath}: {e}")
+                errors.append((rel_path, str(e)))
+
+        if migrated:
+            self.map_store.save()
+
+        return {
+            "migrated": migrated,
+            "missing": missing,
+            "stale": stale,
+            "errors": errors,
+        }
 
     def _count_symbols(self, symbols: list[Symbol] | None) -> int:
         """Count total symbols including children.
@@ -298,7 +371,7 @@ class Indexer:
                 count += self._count_symbols(symbol.children)
         return count
 
-    def update_file(self, filepath: str | Path) -> dict:
+    def update_file(self, filepath: str | Path, *, persist: bool = True) -> dict:
         """Update index for a single file.
 
         Args:
@@ -317,8 +390,9 @@ class Indexer:
                 rel_path = str(filepath)
 
             removed = self.map_store.remove_file(rel_path)
-            self.map_store.update_stats()
-            self.map_store.save()
+            if persist:
+                self.map_store.update_stats()
+                self.map_store.save()
 
             return {
                 "removed": removed,
@@ -337,8 +411,9 @@ class Indexer:
             symbols = self._index_file(filepath)
             new_symbol_count = self._count_symbols(symbols)
 
-            self.map_store.update_stats()
-            self.map_store.save()
+            if persist:
+                self.map_store.update_stats()
+                self.map_store.save()
 
             return {
                 "removed": False,
@@ -360,10 +435,14 @@ class Indexer:
 
         for filepath in stale_files:
             try:
-                self.update_file(self.root / filepath)
+                self.update_file(self.root / filepath, persist=False)
                 updated += 1
             except Exception as e:
                 errors.append((filepath, str(e)))
+
+        if updated:
+            self.map_store.update_stats()
+            self.map_store.save()
 
         return {
             "updated": updated,
@@ -387,6 +466,8 @@ class Indexer:
                 continue
 
             try:
+                if self._metadata_matches(entry, filepath):
+                    continue
                 current_hash = hash_file(filepath)
                 if current_hash != entry.hash:
                     stale.append(rel_path)
@@ -420,6 +501,8 @@ class Indexer:
             return False
 
         try:
+            if self._metadata_matches(entry, full_path):
+                return True
             current_hash = hash_file(full_path)
             return current_hash == entry.hash
         except Exception:

--- a/codemap/core/map_store.py
+++ b/codemap/core/map_store.py
@@ -23,16 +23,23 @@ class FileEntry:
     language: str
     lines: int
     symbols: list[Symbol]
+    size: int | None = None
+    mtime_ns: int | None = None
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
-        return {
+        data = {
             "hash": self.hash,
             "indexed_at": self.indexed_at,
             "language": self.language,
             "lines": self.lines,
             "symbols": [s.to_dict() for s in self.symbols],
         }
+        if self.size is not None:
+            data["size"] = self.size
+        if self.mtime_ns is not None:
+            data["mtime_ns"] = self.mtime_ns
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> "FileEntry":
@@ -43,6 +50,8 @@ class FileEntry:
             language=data["language"],
             lines=data["lines"],
             symbols=[Symbol.from_dict(s) for s in data.get("symbols", [])],
+            size=data.get("size"),
+            mtime_ns=data.get("mtime_ns"),
         )
 
 
@@ -130,6 +139,9 @@ class MapStore:
         self.codemap_dir = self.root / self.CODEMAP_DIR
         self._manifest: Optional[RootManifest] = None
         self._dir_maps: dict[str, DirectoryMap] = {}  # Cache for directory maps
+        self._dirty_dirs: set[str] = set()
+        self._manifest_dirty = False
+        self._tracked_dirs: set[str] | None = None
 
     @property
     def manifest(self) -> RootManifest:
@@ -137,6 +149,12 @@ class MapStore:
         if self._manifest is None:
             self._manifest = self._load_manifest()
         return self._manifest
+
+    def _get_tracked_dirs(self) -> set[str]:
+        """Get the tracked directories as a set for fast membership checks."""
+        if self._tracked_dirs is None:
+            self._tracked_dirs = set(self.manifest.directories)
+        return self._tracked_dirs
 
     @classmethod
     def load(cls, root: Path | None = None) -> "MapStore":
@@ -241,6 +259,7 @@ class MapStore:
         data = dir_map.to_dict()
         with open(map_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, sort_keys=True)
+        self._dirty_dirs.discard(directory)
 
     def save_manifest(self) -> None:
         """Save the root manifest."""
@@ -251,15 +270,18 @@ class MapStore:
         data = self.manifest.to_dict()
         with open(manifest_path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, sort_keys=True)
+        self._manifest_dirty = False
 
     def save(self) -> None:
         """Save all modified directory maps and the manifest."""
-        # Save all cached directory maps
-        for directory in list(self._dir_maps.keys()):
+        if not self._dirty_dirs and not self._manifest_dirty:
+            return
+
+        for directory in sorted(self._dirty_dirs):
             self._save_dir_map(directory)
 
-        # Save manifest
-        self.save_manifest()
+        if self._manifest_dirty:
+            self.save_manifest()
 
     def update_file(
         self,
@@ -268,6 +290,8 @@ class MapStore:
         language: str,
         lines: int,
         symbols: list[Symbol],
+        size: int | None = None,
+        mtime_ns: int | None = None,
     ) -> None:
         """Update or add a file entry.
 
@@ -293,11 +317,17 @@ class MapStore:
             language=language,
             lines=lines,
             symbols=symbols,
+            size=size,
+            mtime_ns=mtime_ns,
         )
+        self._dirty_dirs.add(directory)
 
         # Ensure directory is in the manifest
-        if directory not in self.manifest.directories:
+        tracked_dirs = self._get_tracked_dirs()
+        if directory not in tracked_dirs:
             self.manifest.directories.append(directory)
+            tracked_dirs.add(directory)
+            self._manifest_dirty = True
 
     def remove_file(self, rel_path: str) -> bool:
         """Remove a file entry.
@@ -315,13 +345,18 @@ class MapStore:
         dir_map = self._load_dir_map(directory)
         if filename in dir_map.files:
             del dir_map.files[filename]
+            self._dirty_dirs.add(directory)
 
             # If directory is now empty, remove it from manifest and cache
             if not dir_map.files:
-                if directory in self.manifest.directories:
+                tracked_dirs = self._get_tracked_dirs()
+                if directory in tracked_dirs:
                     self.manifest.directories.remove(directory)
+                    tracked_dirs.remove(directory)
+                    self._manifest_dirty = True
                 if directory in self._dir_maps:
                     del self._dir_maps[directory]
+                self._dirty_dirs.discard(directory)
                 # Remove the empty directory's codemap file
                 map_path = self._get_dir_map_path(directory)
                 if map_path.exists():
@@ -350,6 +385,42 @@ class MapStore:
 
         dir_map = self._load_dir_map(directory)
         return dir_map.files.get(filename)
+
+    def update_file_metadata(
+        self,
+        rel_path: str,
+        *,
+        size: int | None = None,
+        mtime_ns: int | None = None,
+    ) -> bool:
+        """Update stored stat metadata for an indexed file.
+
+        Args:
+            rel_path: Relative path to the file.
+            size: File size in bytes.
+            mtime_ns: File modified time in nanoseconds.
+
+        Returns:
+            True if the entry changed, False otherwise.
+        """
+        entry = self.get_file(rel_path)
+        if entry is None:
+            return False
+
+        changed = False
+        if size is not None and entry.size != size:
+            entry.size = size
+            changed = True
+        if mtime_ns is not None and entry.mtime_ns != mtime_ns:
+            entry.mtime_ns = mtime_ns
+            changed = True
+
+        if changed:
+            path = Path(rel_path)
+            directory = str(path.parent) if path.parent != Path(".") else ""
+            self._dirty_dirs.add(directory)
+
+        return changed
 
     def get_file_hash(self, rel_path: str) -> Optional[str]:
         """Get the hash of a file.
@@ -560,6 +631,7 @@ class MapStore:
             "total_symbols": total_symbols,
             "last_full_index": datetime.now(timezone.utc).isoformat(),
         }
+        self._manifest_dirty = True
 
     def _count_symbols(self, symbols: list[Symbol] | None) -> int:
         """Count total symbols including children.
@@ -588,6 +660,7 @@ class MapStore:
         self.manifest.root = root
         self.manifest.config = config
         self.manifest.generated_at = datetime.now(timezone.utc).isoformat()
+        self._manifest_dirty = True
 
     def get_all_files(self) -> Iterator[tuple[str, FileEntry]]:
         """Iterate over all indexed files.
@@ -609,6 +682,9 @@ class MapStore:
             shutil.rmtree(self.codemap_dir)
         self._manifest = RootManifest()
         self._dir_maps.clear()
+        self._dirty_dirs.clear()
+        self._manifest_dirty = False
+        self._tracked_dirs = None
 
 
 # Legacy compatibility aliases

--- a/codemap/tests/test_cli.py
+++ b/codemap/tests/test_cli.py
@@ -166,6 +166,59 @@ def new_function():
         assert result.exit_code == 0
         assert "Updated 2 files" in result.output
 
+    def test_update_all_migrates_existing_metadata(self, runner, sample_project, monkeypatch):
+        monkeypatch.chdir(sample_project)
+        runner.invoke(cli, ["init", "."])
+
+        root_map_path = sample_project / ".codemap" / "_root.codemap.json"
+        with open(root_map_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        for entry in data["files"].values():
+            entry.pop("size", None)
+            entry.pop("mtime_ns", None)
+
+        with open(root_map_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+
+        result = runner.invoke(cli, ["update", "--all"])
+
+        assert result.exit_code == 0
+        assert "Migrated metadata for 2 files" in result.output
+        assert "Updated 0 files" in result.output
+
+        with open(root_map_path, encoding="utf-8") as f:
+            migrated = json.load(f)
+
+        for entry in migrated["files"].values():
+            assert "size" in entry
+            assert "mtime_ns" in entry
+
+    def test_update_all_migrates_unchanged_entries_but_updates_stale_files(
+        self, runner, sample_project, monkeypatch
+    ):
+        monkeypatch.chdir(sample_project)
+        runner.invoke(cli, ["init", "."])
+
+        root_map_path = sample_project / ".codemap" / "_root.codemap.json"
+        with open(root_map_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        for entry in data["files"].values():
+            entry.pop("size", None)
+            entry.pop("mtime_ns", None)
+
+        with open(root_map_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+
+        (sample_project / "main.py").write_text("def changed(): pass")
+
+        result = runner.invoke(cli, ["update", "--all"])
+
+        assert result.exit_code == 0
+        assert "Migrated metadata for 1 files" in result.output
+        assert "Updated 1 files" in result.output
+
     def test_version_flag(self, runner):
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0

--- a/codemap/tests/test_file_utils.py
+++ b/codemap/tests/test_file_utils.py
@@ -2,7 +2,8 @@
 
 import pytest
 from pathlib import Path
-from codemap.utils.file_utils import get_language, _get_extensions_for_languages
+from codemap.utils.config import Config
+from codemap.utils.file_utils import discover_files, get_language, _get_extensions_for_languages
 
 
 class TestLanguageDetection:
@@ -30,3 +31,13 @@ class TestLanguageDetection:
         expected = [".cs", ".dart", ".go", ".java", ".rs", ".sql"]
         for ext in expected:
             assert ext in extensions, f"{ext} not returned for its language"
+
+    def test_discover_files_skips_excluded_directories(self, tmp_path: Path):
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("def main(): pass")
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "node_modules" / "ignored.py").write_text("def ignored(): pass")
+
+        files = list(discover_files(tmp_path, config=Config(languages=["python"])))
+
+        assert files == [tmp_path / "src" / "main.py"]

--- a/codemap/tests/test_indexer.py
+++ b/codemap/tests/test_indexer.py
@@ -4,6 +4,8 @@ import json
 import pytest
 from pathlib import Path
 
+import codemap.core.indexer as indexer_module
+from codemap.core.hasher import hash_file
 from codemap.core.indexer import Indexer
 from codemap.core.map_store import MapStore
 
@@ -270,6 +272,81 @@ def broken(
         # Should handle gracefully
         assert result["total_files"] == 1
 
+    def test_index_all_avoids_extra_disk_reads(self, tmp_path: Path, monkeypatch):
+        test_file = tmp_path / "test.py"
+        test_file.write_text("def func(): pass")
+
+        def fail_read_text(*args, **kwargs):
+            raise AssertionError("index_all should not call Path.read_text")
+
+        def fail_hash_file(*args, **kwargs):
+            raise AssertionError("index_all should hash the already-read bytes")
+
+        monkeypatch.setattr(Path, "read_text", fail_read_text)
+        monkeypatch.setattr(indexer_module, "hash_file", fail_hash_file)
+
+        indexer = Indexer(root=tmp_path)
+        result = indexer.index_all()
+
+        assert result["total_files"] == 1
+
+    def test_validate_all_skips_hash_when_metadata_matches(self, tmp_path: Path, monkeypatch):
+        test_file = tmp_path / "test.py"
+        test_file.write_text("def func(): pass")
+
+        indexer = Indexer(root=tmp_path)
+        indexer.index_all()
+
+        def fail_hash_file(*args, **kwargs):
+            raise AssertionError("validate_all should not hash unchanged files")
+
+        monkeypatch.setattr(indexer_module, "hash_file", fail_hash_file)
+
+        assert indexer.validate_all() == []
+
+    def test_migrate_missing_file_metadata(self, tmp_path: Path):
+        test_file = tmp_path / "test.py"
+        test_file.write_text("def func(): pass")
+
+        store = MapStore(tmp_path)
+        store.set_metadata(str(tmp_path), {"languages": ["python"]})
+        store.update_file("test.py", hash_file(test_file), "python", 1, symbols=[])
+        store.update_stats()
+        store.save()
+
+        indexer = Indexer.load_existing(tmp_path)
+        result = indexer.migrate_missing_file_metadata()
+
+        assert result["migrated"] == 1
+
+        entry = MapStore.load(tmp_path).get_file("test.py")
+        assert entry is not None
+        assert entry.size == test_file.stat().st_size
+        assert entry.mtime_ns == test_file.stat().st_mtime_ns
+
+    def test_migrate_missing_file_metadata_skips_stale_files(self, tmp_path: Path):
+        test_file = tmp_path / "test.py"
+        test_file.write_text("def func(): pass")
+
+        store = MapStore(tmp_path)
+        store.set_metadata(str(tmp_path), {"languages": ["python"]})
+        store.update_file("test.py", "abc123def456", "python", 1, symbols=[])
+        store.update_stats()
+        store.save()
+
+        test_file.write_text("def modified(): pass")
+
+        indexer = Indexer.load_existing(tmp_path)
+        result = indexer.migrate_missing_file_metadata()
+
+        assert result["migrated"] == 0
+        assert result["stale"] == 1
+
+        entry = MapStore.load(tmp_path).get_file("test.py")
+        assert entry is not None
+        assert entry.size is None
+        assert entry.mtime_ns is None
+
     def test_update_all_stale(self, tmp_path: Path):
         (tmp_path / "file1.py").write_text("def f1(): pass")
         (tmp_path / "file2.py").write_text("def f2(): pass")
@@ -283,6 +360,31 @@ def broken(
 
         result = indexer.update_all_stale()
         assert result["updated"] == 2
+
+    def test_update_all_stale_saves_once(self, tmp_path: Path, monkeypatch):
+        (tmp_path / "file1.py").write_text("def f1(): pass")
+        (tmp_path / "file2.py").write_text("def f2(): pass")
+
+        indexer = Indexer(root=tmp_path)
+        indexer.index_all()
+
+        (tmp_path / "file1.py").write_text("def f1_modified(): pass")
+        (tmp_path / "file2.py").write_text("def f2_modified(): pass")
+
+        save_calls = 0
+        original_save = indexer.map_store.save
+
+        def counted_save():
+            nonlocal save_calls
+            save_calls += 1
+            return original_save()
+
+        monkeypatch.setattr(indexer.map_store, "save", counted_save)
+
+        result = indexer.update_all_stale()
+
+        assert result["updated"] == 2
+        assert save_calls == 1
 
     def test_reindex_clears_previous(self, tmp_path: Path):
         """Test that re-running index_all clears previous index."""

--- a/codemap/tests/test_map_store.py
+++ b/codemap/tests/test_map_store.py
@@ -59,6 +59,42 @@ class TestMapStore:
         assert len(entry.symbols) == 1
         assert entry.symbols[0].name == "MyClass"
 
+    def test_update_file_tracks_stat_metadata(self, tmp_path: Path):
+        store = MapStore(tmp_path)
+
+        store.update_file(
+            rel_path="module.py",
+            hash="hash123",
+            language="python",
+            lines=20,
+            symbols=[],
+            size=123,
+            mtime_ns=456,
+        )
+        store.save()
+
+        loaded = MapStore.load(tmp_path)
+        entry = loaded.get_file("module.py")
+
+        assert entry is not None
+        assert entry.size == 123
+        assert entry.mtime_ns == 456
+
+    def test_update_file_metadata_marks_entry_dirty(self, tmp_path: Path):
+        store = MapStore(tmp_path)
+        store.update_file("module.py", "hash123", "python", 20, symbols=[])
+        store.save()
+
+        loaded = MapStore.load(tmp_path)
+        changed = loaded.update_file_metadata("module.py", size=123, mtime_ns=456)
+        loaded.save()
+
+        assert changed is True
+        entry = MapStore.load(tmp_path).get_file("module.py")
+        assert entry is not None
+        assert entry.size == 123
+        assert entry.mtime_ns == 456
+
     def test_update_file_in_subdirectory(self, tmp_path: Path):
         store = MapStore(tmp_path)
 
@@ -274,6 +310,31 @@ class TestMapStore:
 
         assert not (tmp_path / ".codemap").exists()
         assert store.manifest.directories == []
+
+    def test_save_only_writes_dirty_directory_maps(self, tmp_path: Path, monkeypatch):
+        store = MapStore(tmp_path)
+        store.update_file("src/a.py", "h1", "python", 10, [])
+        store.update_file("lib/b.py", "h2", "python", 10, [])
+        store.save()
+
+        loaded = MapStore.load(tmp_path)
+        assert loaded.get_file("src/a.py") is not None
+        assert loaded.get_file("lib/b.py") is not None
+
+        loaded.update_file("src/a.py", "h3", "python", 12, [])
+
+        saved_dirs = []
+        original_save_dir_map = loaded._save_dir_map
+
+        def record_save(directory: str) -> None:
+            saved_dirs.append(directory)
+            original_save_dir_map(directory)
+
+        monkeypatch.setattr(loaded, "_save_dir_map", record_save)
+
+        loaded.save()
+
+        assert saved_dirs == ["src"]
 
     def test_directory_structure_mirrors_project(self, tmp_path: Path):
         """Test that .codemap mirrors the project structure."""

--- a/codemap/utils/file_utils.py
+++ b/codemap/utils/file_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fnmatch
+import os
 from pathlib import Path
 from typing import Iterator
 
@@ -27,30 +28,30 @@ def discover_files(
     if config is None:
         config = Config()
 
-    # Determine extensions based on languages
-    extensions = _get_extensions_for_languages(languages or config.languages)
+    extensions = set(_get_extensions_for_languages(languages or config.languages))
 
-    for path in root.rglob("*"):
-        if not path.is_file():
-            continue
+    for dirpath_str, dirnames, filenames in os.walk(root, topdown=True):
+        dirpath = Path(dirpath_str)
+        rel_dir = dirpath.relative_to(root)
+        rel_dir_str = "" if rel_dir == Path(".") else rel_dir.as_posix()
 
-        # Check extension
-        if not any(path.suffix == ext for ext in extensions):
-            continue
+        kept_dirs = []
+        for dirname in dirnames:
+            rel_child = dirname if not rel_dir_str else f"{rel_dir_str}/{dirname}"
+            if should_exclude(rel_child, config.exclude_patterns):
+                continue
+            kept_dirs.append(dirname)
+        dirnames[:] = kept_dirs
 
-        # Get relative path for pattern matching
-        try:
-            rel_path = path.relative_to(root)
-        except ValueError:
-            continue
+        for filename in filenames:
+            if Path(filename).suffix not in extensions:
+                continue
 
-        rel_str = str(rel_path)
+            rel_path = filename if not rel_dir_str else f"{rel_dir_str}/{filename}"
+            if should_exclude(rel_path, config.exclude_patterns):
+                continue
 
-        # Check exclude patterns
-        if should_exclude(rel_str, config.exclude_patterns):
-            continue
-
-        yield path
+            yield dirpath / filename
 
 
 def should_exclude(filepath: str, patterns: list[str] | None = None) -> bool:


### PR DESCRIPTION
## Summary

This speeds up `codemap` on large repositories by reducing redundant file reads, avoiding re-hashing unchanged files during `update --all`, batching persistence work, and pruning excluded directories earlier during discovery.

It also keeps existing `.codemap` directories compatible by migrating missing `size` and `mtime_ns` metadata during `update`, while still reindexing stale files correctly.

## Benchmark

Benchmarked `HEAD` vs the current branch using the same `.venv` and isolated temp repos.

| Scenario | Before | After | Speedup | Reduction |
| --- | ---: | ---: | ---: | ---: |
| `init` with 1,500 indexed files + 8,000 excluded files | 3.69s | 2.53s | 1.46x | 31.3% |
| `update --all` steady state with 3,000 indexed files, 30 changed | 11.67s | 0.52s | 22.3x | 95.5% |
| `update --all` on a legacy index missing metadata, 3,000 indexed files, 30 changed | 15.27s | 6.26s | 2.44x | 59.0% |