### PR TITLE
docs: update Ruby parser support references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ codemap/
 │   ├── cpp_parser.py         # tree-sitter based
 │   ├── html_parser.py        # tree-sitter based
 │   ├── css_parser.py         # tree-sitter based
+│   ├── ruby_parser.py        # tree-sitter based
 │   ├── markdown_parser.py    # Regex-based H2/H3/H4 headers
 │   └── yaml_parser.py        # Recursive key hierarchy
 ├── hooks/
@@ -345,6 +346,9 @@ tree-sitter-css>=0.23
 # For SQL parsing
 tree-sitter-sql>=0.3
 
+# For Ruby parsing
+tree-sitter-ruby>=0.21
+
 # Dev
 pytest>=7.0
 ```
@@ -377,7 +381,7 @@ codemap watch . &                   # Start watch mode (auto-updates index)
 ```
 
 ### Supported Languages
-Python, TypeScript, JavaScript, Kotlin, Swift, Go, Java, C#, Rust, C, C++, PHP, Dart, SQL, HTML, CSS, Markdown, YAML
+Python, TypeScript, JavaScript, Kotlin, Swift, Go, Java, C#, Rust, C, C++, PHP, Dart, SQL, Ruby, HTML, CSS, Markdown, YAML
 
 ### Workflow
 1. **Start watch mode**: `codemap watch . &` (run once per session)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -563,7 +563,6 @@ Looking for something to work on? Here are high-impact areas:
   - [ ] Rust  
   - [ ] Java
   - [ ] C#
-  - [ ] Ruby
   - [ ] PHP
 - **CLI improvements:**
   - [ ] JSON output format (`--json` flag)

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ pip install -e ".[all]"
 | **Kotlin** | tree-sitter | see below | class, interface, function, method, object |
 | **Swift** | tree-sitter | see below | class, struct, protocol, enum, function, method |
 | **PHP** | tree-sitter | see below | class, interface, trait, enum, function, method |
+| **Ruby** | tree-sitter | see below | module, class, method, singleton_method |
 | **Go** | tree-sitter | see below | function, method, struct, interface, type |
 | **Java** | tree-sitter | see below | class, interface, enum, method |
 | **C#** | tree-sitter | see below | class, interface, struct, enum, method, property |
@@ -431,6 +432,7 @@ pip install "codemap[c] @ git+https://github.com/AZidan/codemap.git"           #
 pip install "codemap[cpp] @ git+https://github.com/AZidan/codemap.git"         # C++
 pip install "codemap[html] @ git+https://github.com/AZidan/codemap.git"        # HTML
 pip install "codemap[css] @ git+https://github.com/AZidan/codemap.git"         # CSS
+pip install "codemap[ruby] @ git+https://github.com/AZidan/codemap.git"        # Ruby
 
 # Install all languages
 pip install "codemap[languages] @ git+https://github.com/AZidan/codemap.git"
@@ -641,6 +643,7 @@ codemap/
 │   ├── cpp_parser.py      # C++ tree-sitter parser
 │   ├── html_parser.py     # HTML tree-sitter parser
 │   ├── css_parser.py      # CSS tree-sitter parser
+│   ├── ruby_parser.py     # Ruby tree-sitter parser
 │   ├── markdown_parser.py # Markdown regex parser
 │   └── yaml_parser.py     # YAML parser
 ├── hooks/
@@ -656,7 +659,7 @@ codemap/
 
 Contributions welcome! Areas where help is needed:
 
-- **New language parsers** — Ruby, PHP, Scala
+- **New language parsers** — PHP, Scala
 - **MCP server mode** — For non-Claude tools
 - **Fuzzy symbol search** — `codemap find "usr srv"` → `UserService`
 - **VSCode extension** — GUI for non-CLI users

--- a/docs/AI_ASSISTANT_INSTRUCTIONS.md
+++ b/docs/AI_ASSISTANT_INSTRUCTIONS.md
@@ -87,7 +87,7 @@ Now you can read just the specific method you need (e.g., lines 100-145 for `cre
 
 | Type | Description | Languages |
 |------|-------------|-----------|
-| `class` | Class declaration | Python, TS/JS, Kotlin, Swift, Java, C#, C++, Go (struct) |
+| `class` | Class declaration | Python, TS/JS, Kotlin, Swift, Java, C#, C++, Ruby, Go (struct) |
 | `function` | Function declaration | All languages |
 | `method` | Class/struct method | All languages |
 | `async_function` | Async function | Python, TS/JS |
@@ -98,6 +98,8 @@ Now you can read just the specific method you need (e.g., lines 100-145 for `cre
 | `struct` | Struct declaration | Swift, Go, C#, Rust, C, C++ |
 | `trait` | Trait declaration | Rust |
 | `object` | Object declaration | Kotlin |
+| `module` | Module declaration | Ruby |
+| `singleton_method` | Class/singleton method | Ruby |
 | `typedef` | Type definition | C |
 | `namespace` | Namespace declaration | C++ |
 | `template` | Template class/function | C++ |

--- a/docs/CODEMAP_INSTRUCTIONS_EMBED.md
+++ b/docs/CODEMAP_INSTRUCTIONS_EMBED.md
@@ -25,7 +25,7 @@ codemap watch . &                   # Start watch mode (auto-updates index)
 ```
 
 ### Supported Languages
-Python, TypeScript, JavaScript, Kotlin, Swift, Go, Java, C#, Rust, C, C++, Markdown, YAML
+Python, TypeScript, JavaScript, Kotlin, Swift, Go, Java, C#, Rust, C, C++, Ruby, Markdown, YAML
 
 ### Workflow
 1. **Start watch mode**: `codemap watch . &` (run once per session)

--- a/docs/plans/language-support-roadmap.md
+++ b/docs/plans/language-support-roadmap.md
@@ -4,13 +4,13 @@
 
 ## Current Status
 
-**Supported Languages (18):**
+**Supported Languages (19):**
 - Python (stdlib ast)
 - TypeScript, JavaScript (tree-sitter)
 - Kotlin, Swift, Dart (tree-sitter)
 - Go, Java, C#, Rust (tree-sitter)
 - C, C++ (tree-sitter)
-- PHP, SQL (tree-sitter)
+- PHP, Ruby, SQL (tree-sitter)
 - HTML, CSS (tree-sitter)
 - Markdown, YAML (custom parsers)
 
@@ -43,7 +43,7 @@ Languages ranked by combined popularity from [TIOBE Index](https://www.tiobe.com
 | 12 | HTML | - | #2 (54%) | ✅ Done | tree-sitter-html |
 | 13 | CSS/SCSS | - | #6 (42%) | ✅ Done | tree-sitter-css |
 | 14 | Bash/Shell | - | #7 (33%) | ⏳ Planned | tree-sitter-bash |
-| 15 | Ruby | #18 | #17 (6%) | ⏳ Planned | tree-sitter-ruby |
+| 15 | Ruby | #18 | #17 (6%) | ✅ Done | tree-sitter-ruby |
 | 16 | Kotlin | #15 | #15 (9%) | ✅ Done | tree-sitter-kotlin |
 | 17 | Swift | #16 | #16 (6%) | ✅ Done | tree-sitter-swift |
 | 18 | Lua | #26 | #21 (4%) | ⏳ Planned | tree-sitter-lua |
@@ -55,7 +55,7 @@ Languages ranked by combined popularity from [TIOBE Index](https://www.tiobe.com
 | 24 | Elixir | #40 | #28 (3%) | ⏳ Planned | tree-sitter-elixir |
 | 25 | Haskell | #29 | #29 (2%) | ⏳ Planned | tree-sitter-haskell |
 
-**Tier 2 Completion: 6/15 (40%)**
+**Tier 2 Completion: 7/15 (47%)**
 
 ### Tier 3: Medium Priority (Config/Data Languages)
 
@@ -133,6 +133,12 @@ Symbols: table, view, materialized_view, index, function, trigger, type, sequenc
 File extensions: .sql
 ```
 
+**Ruby Parser** ✅
+```
+Symbols: module, class, method, singleton_method
+File extensions: .rb, .rake, .gemspec, .ru, .thor
+```
+
 ### Phase 3: Shell & DevOps
 
 **Bash Parser**
@@ -205,10 +211,10 @@ Instead of individual packages, consider using [tree-sitter-language-pack](https
 | Tier | Total | Done | Remaining | Completion |
 |------|-------|------|-----------|------------|
 | Tier 1 (Critical) | 10 | 10 | 0 | 100% ✅ |
-| Tier 2 (High Priority) | 15 | 6 | 9 | 40% |
+| Tier 2 (High Priority) | 15 | 7 | 8 | 47% |
 | Tier 3 (Config/Data) | 8 | 0 | 8 | 0% |
 | Tier 4 (Emerging) | 10 | 0 | 10 | 0% |
-| **Total** | **43** | **16** | **27** | **37%** |
+| **Total** | **43** | **17** | **26** | **40%** |
 
 ---
 
@@ -221,5 +227,6 @@ Instead of individual packages, consider using [tree-sitter-language-pack](https
 5. [x] Add CSS parser (Tier 2) ✅
 6. [x] Add Dart parser (Tier 2) - Mobile dev priority ✅
 7. [x] Add SQL parser (Tier 2) - Database queries ✅
-8. [ ] Add Bash parser (Tier 2) - DevOps scripts
-9. [ ] Evaluate tree-sitter-language-pack vs individual packages
+8. [x] Add Ruby parser (Tier 2) - Rails/Ruby projects ✅
+9. [ ] Add Bash parser (Tier 2) - DevOps scripts
+10. [ ] Evaluate tree-sitter-language-pack vs individual packages

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -30,6 +30,9 @@ pip install tree-sitter-swift
 
 # C/C++
 pip install tree-sitter-c tree-sitter-cpp
+
+# Ruby
+pip install tree-sitter-ruby
 ```
 
 ### Install the Plugin
@@ -79,6 +82,7 @@ You can also explicitly ask Claude to use CodeMap:
 | **TypeScript/JavaScript** | Classes, functions, methods, interfaces, types, enums |
 | **Kotlin** | Classes, interfaces, objects, functions |
 | **Swift** | Structs, classes, protocols, enums, functions |
+| **Ruby** | Modules, classes, methods, singleton methods |
 | **C** | Functions, structs, enums, typedefs |
 | **C++** | Classes, structs, functions, methods, namespaces, enums, templates |
 | **Markdown** | H2/H3/H4 sections |

--- a/plugin/skills/codemap/SKILL.md
+++ b/plugin/skills/codemap/SKILL.md
@@ -96,6 +96,8 @@ Symbols:
 | `interface` | TypeScript interface |
 | `type` | TypeScript type alias |
 | `enum` | Enum declaration |
+| `module` | Ruby module |
+| `singleton_method` | Ruby singleton/class method |
 
 ## Index Structure
 


### PR DESCRIPTION
## Summary

- Updates docs and assistant instructions to list Ruby as supported
- Marks Ruby parser support as done in the language roadmap
- Removes Ruby from help-wanted parser lists
